### PR TITLE
SELC-2976 Added onboardedInfo API call in order to retrieve partyId and use it for redirect to dashboard

### DIFF
--- a/openApi/onboarding-pnpg-api-docs.json
+++ b/openApi/onboarding-pnpg-api-docs.json
@@ -54,7 +54,7 @@
           {
             "name": "productFilter",
             "in": "query",
-            "description": "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product. ",
+            "description": "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
             "required": false,
             "style": "form",
             "schema": {
@@ -287,6 +287,96 @@
         ]
       }
     },
+    "/institutions/geographicTaxonomies": {
+      "get": {
+        "tags": ["institutions"],
+        "summary": "getGeographicTaxonomiesByTaxCodeAndSubunitCode",
+        "description": "The service retrieve the institution's geographic taxonomy",
+        "operationId": "getGeographicTaxonomiesByTaxCodeAndSubunitCodeUsingGET",
+        "parameters": [
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "Institution's taxCode",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "Institution's subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeographicTaxonomyResource"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": ["global"]
+          }
+        ]
+      }
+    },
     "/institutions/onboarding": {
       "post": {
         "tags": ["institutions"],
@@ -407,6 +497,27 @@
             "style": "form",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "vatNumber",
+            "in": "query",
+            "description": "Institution's VAT number",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verifyType",
+            "in": "query",
+            "description": "Onboarding verification method type",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "enum": ["EXTERNAL", "INTERNAL"]
             }
           }
         ],
@@ -2007,15 +2118,6 @@
       },
       "BillingDataDto": {
         "title": "BillingDataDto",
-        "required": [
-          "businessName",
-          "digitalAddress",
-          "recipientCode",
-          "registeredOffice",
-          "taxCode",
-          "vatNumber",
-          "zipCode"
-        ],
         "type": "object",
         "properties": {
           "businessName": {
@@ -2258,6 +2360,10 @@
           "companyInformations": {
             "description": "GPS, SCP, PT optional data",
             "$ref": "#/components/schemas/CompanyInformationsResource"
+          },
+          "id": {
+            "type": "string",
+            "description": "Institution's unique internal Id"
           },
           "institutionType": {
             "type": "string",

--- a/src/api/OnboardingApiClient.tsx
+++ b/src/api/OnboardingApiClient.tsx
@@ -10,6 +10,7 @@ import { InstitutionTypeEnum } from './generated/b4f-onboarding-pnpg/CompanyOnbo
 import { RoleEnum, CompanyUserDto } from './generated/b4f-onboarding-pnpg/CompanyUserDto';
 import { MatchInfoResultResource } from './generated/b4f-onboarding-pnpg/MatchInfoResultResource';
 import { InstitutionLegalAddressResource } from './generated/b4f-onboarding-pnpg/InstitutionLegalAddressResource';
+import { InstitutionOnboardingInfoResource } from './generated/b4f-onboarding-pnpg/InstitutionOnboardingInfoResource';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
@@ -101,6 +102,17 @@ export const OnboardingApi = {
           role: 'MANAGER' as RoleEnum,
         },
       },
+    });
+    return extractResponse(result, 200, onRedirectToLogin);
+  },
+
+  getInstitutionOnboardingInfo: async (
+    taxCode: string,
+    productId: string
+  ): Promise<InstitutionOnboardingInfoResource> => {
+    const result = await apiClient.getInstitutionOnboardingInfoUsingGET({
+      taxCode,
+      productId,
     });
     return extractResponse(result, 200, onRedirectToLogin);
   },

--- a/src/api/__mocks__/OnboardingApiClient.tsx
+++ b/src/api/__mocks__/OnboardingApiClient.tsx
@@ -1,6 +1,7 @@
 import { LegalEntity, BusinessLegalAddress, User } from '../../types';
 import { BusinessResourceIC } from '../generated/b4f-onboarding-pnpg/BusinessResourceIC';
 import { InstitutionLegalAddressResource } from '../generated/b4f-onboarding-pnpg/InstitutionLegalAddressResource';
+import { InstitutionOnboardingInfoResource } from '../generated/b4f-onboarding-pnpg/InstitutionOnboardingInfoResource';
 import { MatchInfoResultResource } from '../generated/b4f-onboarding-pnpg/MatchInfoResultResource';
 
 export const loggedUser: User = {
@@ -159,4 +160,14 @@ export const mockedOnboardingApi = {
       return new Promise((resolve) => resolve(matchedBusinessLegalAddressByExternalId ?? null));
     }
   },
+
+  getInstitutionOnboardingInfo: (_taxCode: string): Promise<InstitutionOnboardingInfoResource> =>
+    new Promise((resolve) =>
+      resolve({
+        geographicTaxonomies: [],
+        institution: {
+          id: 'mockedPartyId01',
+        },
+      })
+    ),
 };

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -5,6 +5,7 @@ import { mockedLegalEntity } from '../api/__mocks__/OnboardingApiClient';
 import { MatchInfoResultResource } from '../api/generated/b4f-onboarding-pnpg/MatchInfoResultResource';
 import { InstitutionLegalAddressResource } from '../api/generated/b4f-onboarding-pnpg/InstitutionLegalAddressResource';
 import { CompanyUserDto, RoleEnum } from '../api/generated/b4f-onboarding-pnpg/CompanyUserDto';
+import { InstitutionOnboardingInfoResource } from '../api/generated/b4f-onboarding-pnpg/InstitutionOnboardingInfoResource';
 
 export const getBusinessesByUser = (): Promise<LegalEntity> => {
   /* istanbul ignore if */
@@ -35,6 +36,18 @@ export const getBusinessLegalAddress = (
     return mockedOnboardingApi.getBusinessLegalAddress(businessId);
   } else {
     return OnboardingApi.getBusinessLegalAddress(businessId);
+  }
+};
+
+export const getInstitutionOnboardingInfo = (
+  taxCode: string,
+  productId: string
+): Promise<InstitutionOnboardingInfoResource> => {
+  /* istanbul ignore if */
+  if (process.env.REACT_APP_MOCK_API === 'true') {
+    return mockedOnboardingApi.getInstitutionOnboardingInfo(taxCode);
+  } else {
+    return OnboardingApi.getInstitutionOnboardingInfo(taxCode, productId);
   }
 };
 

--- a/src/views/OnboardingPNPG/Onboarding.tsx
+++ b/src/views/OnboardingPNPG/Onboarding.tsx
@@ -13,6 +13,7 @@ function OnboardingComponent() {
   const [_loading, setLoading] = useState<boolean>(false);
   const [activeStep, setActiveStep] = useState(0);
   const [retrievedBusinesses, setRetrievedBusinesses] = useState<LegalEntity>();
+  const [retrievedPartyId, setRetrievedPartyId] = useState<string>();
 
   const forward = () => {
     setActiveStep(activeStep + 1);
@@ -54,13 +55,14 @@ function OnboardingComponent() {
       label: 'Submit',
       Component: () =>
         StepSubmit({
-          forward,
           setLoading,
+          forward,
+          setRetrievedPartyId,
         }),
     },
     {
       label: 'Success',
-      Component: () => StepSuccess(),
+      Component: () => StepSuccess({ retrievedPartyId }),
     },
   ];
 

--- a/src/views/OnboardingPNPG/components/StepSuccess.tsx
+++ b/src/views/OnboardingPNPG/components/StepSuccess.tsx
@@ -1,14 +1,14 @@
 import { IllusCompleted } from '@pagopa/mui-italia';
 import EndingPage from '@pagopa/selfcare-common-frontend/components/EndingPage';
 import { useTranslation } from 'react-i18next';
-import { useHistoryState } from '../../../components/useHistoryState';
-import { Business } from '../../../types';
 import { ENV } from '../../../utils/env';
 
-function StepSuccess() {
-  const { t } = useTranslation();
+type Props = {
+  retrievedPartyId?: string;
+};
 
-  const selectedBusiness = useHistoryState<Business | undefined>('selected_business', undefined)[0];
+function StepSuccess({ retrievedPartyId }: Props) {
+  const { t } = useTranslation();
 
   return (
     <EndingPage
@@ -20,7 +20,7 @@ function StepSuccess() {
       variantDescription={'body1'}
       buttonLabel={t('outcome.success.signIn')}
       onButtonClick={() =>
-        window.location.assign(ENV.URL_FE.DASHBOARD + '/' + `${selectedBusiness?.businessTaxId}`)
+        window.location.assign(ENV.URL_FE.DASHBOARD + '/' + `${retrievedPartyId}`)
       }
     />
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Release in UAT environment of Added onboardedInfo API call in order to retrieve partyId and use it for redirect to dashboard

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This improvement emerged following the refactor of the models in the dashboard, as with the previous logic the externalId would have been added to the BaseInstitutionResource model. The logic on the pnpg dashboard frontend was therefore simplified as now, thanks to this API call, we have the newly onboarded or already registered partyId available.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local with mock cases and pointing to the dev data from local
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.