### PR TITLE
[PNPG-229] feat: Managed already onboarded businesses following the select and the insert taxCode steps + added unit tests

### DIFF
--- a/src/api/__mocks__/OnboardingApiClient.tsx
+++ b/src/api/__mocks__/OnboardingApiClient.tsx
@@ -54,10 +54,10 @@ export const mockedEdAOccurrences = [
     fiscalCode: '55555555555',
     geographicTaxonomies: [],
     id: '55555555555',
-    institutionType: 'GSP',
-    mailAddress: 'test@comuneditest.it',
+    institutionType: 'PG',
+    mailAddress: 'test@impresa1.it',
     name: 'retrieved in EdA mock 1',
-    origin: 'testorigin3',
+    origin: 'ADE',
     originId: 'testoriginId3',
     recipientCode: 'MDSSFDF',
     status: 'TestStatus3',
@@ -65,15 +65,15 @@ export const mockedEdAOccurrences = [
     zipCode: '32145',
   },
   {
-    externalId: '66666666666',
+    externalId: '51515151511',
     category: 'test3',
-    fiscalCode: '66666666666',
+    fiscalCode: '51515151511',
     geographicTaxonomies: [],
-    id: '66666666666',
-    institutionType: 'GSP',
-    mailAddress: 'test@comuneditest.it',
+    id: '51515151511',
+    institutionType: 'PG',
+    mailAddress: 'test@impresa1.it',
     name: 'retrieved in EdA mock 2',
-    origin: 'testorigin3',
+    origin: 'ADE',
     originId: 'testoriginId3',
     recipientCode: 'MDSSFDF',
     status: 'TestStatus3',
@@ -87,24 +87,7 @@ export const mockedOnboardingApi = {
     new Promise((resolve) => resolve(mockedLegalEntity)),
 
   onboardingPGSubmit: (businessId: string): Promise<boolean> => {
-    if (businessId === '01501320442') {
-      return new Promise(() => {
-        const error = new Error(`Unexpected mocked HTTP status! Expected 201 obtained 409`);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // eslint-disable-next-line functional/immutable-data
-        error.httpStatus = 409;
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // eslint-disable-next-line functional/immutable-data
-        error.httpBody = {
-          statusCode: 409,
-          description: 'Conflict Error',
-        };
-        console.error(JSON.stringify(error));
-        throw error;
-      });
-    } else if (businessId === '22222222222') {
+    if (businessId === '22222222222') {
       return new Promise(() => {
         const error = new Error(`Unexpected mocked HTTP status! Expected 201 obtained 404`);
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -161,13 +144,20 @@ export const mockedOnboardingApi = {
     }
   },
 
-  getInstitutionOnboardingInfo: (_taxCode: string): Promise<InstitutionOnboardingInfoResource> =>
-    new Promise((resolve) =>
-      resolve({
-        geographicTaxonomies: [],
-        institution: {
-          id: 'mockedPartyId01',
-        },
-      })
-    ),
+  getInstitutionOnboardingInfo: (taxCode: string): Promise<InstitutionOnboardingInfoResource> => {
+    switch (taxCode) {
+      case '01501320442':
+      case '51515151511':
+        return new Promise((resolve) =>
+          resolve({
+            geographicTaxonomies: [],
+            institution: {
+              id: 'retrievedPartyId01',
+            },
+          })
+        );
+      default:
+        return new Promise((resolve) => resolve({}));
+    }
+  },
 };

--- a/src/views/OnboardingPNPG/Onboarding.tsx
+++ b/src/views/OnboardingPNPG/Onboarding.tsx
@@ -1,9 +1,12 @@
 import { Container } from '@mui/material';
 import { useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { EndingPage } from '@pagopa/selfcare-common-frontend/lib';
 import { LegalEntity, StepperStep } from '../../types';
 import { withLogin } from '../../components/withLogin';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
+import { ReactComponent as AlreadyOnboardedIcon } from '../../assets/alreadyOnboarded.svg';
+import { ENV } from '../../utils/env';
 import StepAddCompany from './components/StepAddCompany';
 import StepRetrieveBusinesses from './components/StepRetrieveBusinesses';
 import StepSelectBusiness from './components/StepSelectBusiness';
@@ -38,6 +41,8 @@ function OnboardingComponent() {
         StepSelectBusiness({
           retrievedBusinesses,
           setActiveStep,
+          setRetrievedPartyId,
+          setLoading,
           forward,
         }),
     },
@@ -46,6 +51,7 @@ function OnboardingComponent() {
       Component: () =>
         StepAddCompany({
           setActiveStep,
+          setRetrievedPartyId,
           setLoading,
         }),
     },
@@ -62,7 +68,6 @@ function OnboardingComponent() {
         StepSubmit({
           setLoading,
           forward,
-          setRetrievedPartyId,
         }),
     },
     {
@@ -75,8 +80,27 @@ function OnboardingComponent() {
 
   return (
     <Container>
-      <Step />
       {loading && <LoadingOverlay loadingText={t('loadingText')} />}
+      {retrievedPartyId ? (
+        <EndingPage
+          icon={<AlreadyOnboardedIcon />}
+          title={t('alreadyOnboarded.title')}
+          description={
+            <Trans i18nKey="alreadyOnboarded.description">
+              Questa impresa è già stata registrata. Accedi per leggere le <br />
+              notifiche e aggiungere altri utenti.
+            </Trans>
+          }
+          variantTitle={'h4'}
+          variantDescription={'body1'}
+          buttonLabel={t('alreadyOnboarded.signIn')}
+          onButtonClick={() =>
+            window.location.assign(ENV.URL_FE.DASHBOARD + '/' + `${retrievedPartyId}`)
+          }
+        />
+      ) : (
+        <Step />
+      )}
     </Container>
   );
 }

--- a/src/views/OnboardingPNPG/__tests__/Onboarding.test.tsx
+++ b/src/views/OnboardingPNPG/__tests__/Onboarding.test.tsx
@@ -107,7 +107,6 @@ test('Test: Onboarding flow after retrieve business from Infocamere, with succes
 test('Test: Onboarding flow after retrieve business from Infocamere with alreadyOnboarded outcome on submit', async () => {
   renderComponent();
   await executeStepSelectBusiness('BusinessName alreadyOnboarded');
-  await executeStepBusinessData();
 
   await waitFor(() => screen.getByText('Impresa già registrata'));
 
@@ -153,7 +152,18 @@ test('Test: In the add agency flow via taxCode, when inserting a taxCode that MA
   fireEvent.click(backToAccessButton);
 });
 
-test('Test: In the add agency flow via taxCode, when inserting a taxCode that NOT match with legalAddress API but match with AdE API, the success page will be show', async () => {
+test('Test: In the add agency flow via taxCode, when inserting a taxCode of already onboarded business that NOT match with legalAddress API but match with AdE API, the already onboarded page will be show', async () => {
+  renderComponent();
+  await executeStepSelectBusiness();
+  await executeStepAddCompany('51515151511');
+
+  await waitFor(() => screen.getByText('Impresa già registrata'));
+
+  const signInButton = screen.getByText('Accedi');
+  fireEvent.click(signInButton);
+});
+
+test('Test: In the add agency flow via taxCode, when inserting a taxCode of NOT already onboarded business that NOT match with legalAddress API but match with AdE API, the success page will be show', async () => {
   renderComponent();
   await executeStepSelectBusiness();
   await executeStepAddCompany('55555555555');


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[PNPG-229] feat: Managed already onboarded businesses following the select and the insert taxCode steps + added unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to notify the user if the company has already been registered by another legal representative, in order to avoid completing the other steps. Removed previous handling done on submit as it will now be unused.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environments creating consistent use cases to replicate the use case; also added unit tests to verify that the desired behavior is respected in both possible scenarios.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[PNPG-229]: https://pagopa.atlassian.net/browse/PNPG-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ