### PR TITLE
[PNPG-262] feat: Added resource instead of object with dynamic keys type boolean in check-manager response and used the generated model

### DIFF
--- a/openApi/generated-onboarding/onboarding-swagger20.json
+++ b/openApi/generated-onboarding/onboarding-swagger20.json
@@ -1079,10 +1079,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "additionalProperties": {
-                "type": "boolean"
-              },
-              "type": "object"
+              "$ref": "#/definitions/ManagerResultResource"
             }
           },
           "400": {
@@ -1208,6 +1205,79 @@
         "description": "The service allows the onboarding of Users",
         "operationId": "onboardingUsingPOST_4",
         "summary": "onboarding"
+      }
+    },
+    "/v1/users/onboarding/aggregator": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/OnboardingUserDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "user"
+        ],
+        "description": "The service allows the onboarding of Users for aggregators",
+        "operationId": "onboardingAggregatorUsingPOST",
+        "summary": "onboardingAggregator"
       }
     },
     "/v1/users/validate": {
@@ -2476,6 +2546,9 @@
         "originId": {
           "type": "string"
         },
+        "parentDescription": {
+          "type": "string"
+        },
         "recipientCode": {
           "type": "string"
         },
@@ -2541,6 +2614,9 @@
           "type": "string"
         },
         "originId": {
+          "type": "string"
+        },
+        "parentDescription": {
           "type": "string"
         },
         "recipientCode": {
@@ -3391,6 +3467,17 @@
         "reason"
       ],
       "title": "InvalidParam",
+      "type": "object"
+    },
+    "ManagerResultResource": {
+      "properties": {
+        "result": {
+          "description": "Indicate if the manager match with the current",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "title": "ManagerResultResource",
       "type": "object"
     },
     "MatchInfoResultResource": {

--- a/openApi/onboarding-api-docs.json
+++ b/openApi/onboarding-api-docs.json
@@ -2565,10 +2565,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "object",
-                  "additionalProperties" : {
-                    "type" : "boolean"
-                  }
+                  "$ref" : "#/components/schemas/ManagerResultResource"
                 }
               }
             }
@@ -2645,6 +2642,91 @@
         "summary" : "onboarding",
         "description" : "The service allows the onboarding of Users",
         "operationId" : "onboardingUsingPOST_4",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingUserDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v1/users/onboarding/aggregator" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "onboardingAggregator",
+        "description" : "The service allows the onboarding of Users for aggregators",
+        "operationId" : "onboardingAggregatorUsingPOST",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2930,6 +3012,9 @@
           "originId" : {
             "type" : "string"
           },
+          "parentDescription" : {
+            "type" : "string"
+          },
           "recipientCode" : {
             "type" : "string"
           },
@@ -2991,6 +3076,9 @@
             "type" : "string"
           },
           "originId" : {
+            "type" : "string"
+          },
+          "parentDescription" : {
             "type" : "string"
           },
           "recipientCode" : {
@@ -3754,6 +3842,17 @@
           "verificationResult" : {
             "type" : "boolean",
             "description" : "Legal Representative and Institution match result on Agenzia delle Entrate",
+            "example" : false
+          }
+        }
+      },
+      "ManagerResultResource" : {
+        "title" : "ManagerResultResource",
+        "type" : "object",
+        "properties" : {
+          "result" : {
+            "type" : "boolean",
+            "description" : "Indicate if the manager match with the current",
             "example" : false
           }
         }

--- a/src/api/OnboardingApiClient.tsx
+++ b/src/api/OnboardingApiClient.tsx
@@ -14,6 +14,7 @@ import { RoleEnum, CompanyUserDto } from './generated/b4f-onboarding/CompanyUser
 import { MatchInfoResultResource } from './generated/b4f-onboarding/MatchInfoResultResource';
 import { InstitutionLegalAddressResource } from './generated/b4f-onboarding/InstitutionLegalAddressResource';
 import { InstitutionOnboardingResource } from './generated/b4f-onboarding/InstitutionOnboardingResource';
+import { ManagerResultResource } from './generated/b4f-onboarding/ManagerResultResource';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
@@ -120,7 +121,7 @@ export const OnboardingApi = {
     return extractResponse(result, 200, onRedirectToLogin);
   },
 
-  checkManager: async (loggedUser: User, taxCode?: string): Promise<boolean> => {
+  checkManager: async (loggedUser: User, taxCode?: string): Promise<ManagerResultResource> => {
     const result = await apiClient.checkManager({
       body: {
         institutionType: 'PG' as InstitutionTypeEnum,

--- a/src/api/__mocks__/OnboardingApiClient.tsx
+++ b/src/api/__mocks__/OnboardingApiClient.tsx
@@ -3,6 +3,7 @@ import { BusinessResourceIC } from '../generated/b4f-onboarding/BusinessResource
 import { InstitutionLegalAddressResource } from '../generated/b4f-onboarding/InstitutionLegalAddressResource';
 import { MatchInfoResultResource } from '../generated/b4f-onboarding/MatchInfoResultResource';
 import { InstitutionOnboardingResource } from '../generated/b4f-onboarding/InstitutionOnboardingResource';
+import { ManagerResultResource } from '../generated/b4f-onboarding/ManagerResultResource';
 
 export const loggedUser: User = {
   uid: '00123',
@@ -187,14 +188,14 @@ export const mockedOnboardingApi = {
     }
   },
 
-  checkManager: async (taxCode?: string): Promise<boolean> => {
+  checkManager: async (taxCode?: string): Promise<ManagerResultResource> => {
     switch (taxCode) {
       case '12323231321':
-        return true;
+        return new Promise((resolve) => resolve({ result: true }));
       case '55555555555':
-        return false;
+        return new Promise((resolve) => resolve({ result: false }));
       default:
-        return false;
+        return new Promise((resolve) => resolve({ result: false }));
     }
   },
 };

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -6,6 +6,7 @@ import { MatchInfoResultResource } from '../api/generated/b4f-onboarding/MatchIn
 import { InstitutionLegalAddressResource } from '../api/generated/b4f-onboarding/InstitutionLegalAddressResource';
 import { CompanyUserDto, RoleEnum } from '../api/generated/b4f-onboarding/CompanyUserDto';
 import { InstitutionOnboardingResource } from '../api/generated/b4f-onboarding/InstitutionOnboardingResource';
+import { ManagerResultResource } from '../api/generated/b4f-onboarding/ManagerResultResource';
 
 export const getBusinessesByUser = (): Promise<LegalEntity> => {
   /* istanbul ignore if */
@@ -51,7 +52,10 @@ export const getInstitutionOnboardingInfo = (
   }
 };
 
-export const checkManager = (loggedUser: User, taxCode?: string): Promise<boolean> => {
+export const checkManager = async (
+  loggedUser: User,
+  taxCode?: string
+): Promise<ManagerResultResource> => {
   /* istanbul ignore if */
   if (process.env.REACT_APP_MOCK_API === 'true') {
     return mockedOnboardingApi.checkManager(taxCode);

--- a/src/utils/models/VerificationResult.ts
+++ b/src/utils/models/VerificationResult.ts
@@ -1,0 +1,3 @@
+export type VerificationResult = {
+  result: boolean;
+};

--- a/src/views/OnboardingPNPG/components/StepAddCompany.tsx
+++ b/src/views/OnboardingPNPG/components/StepAddCompany.tsx
@@ -84,18 +84,18 @@ function StepAddCompany({ setActiveStep, setLoading, setOnboardingData, back }: 
         techDescription: `An error occurred while retrieving onboarded party of ${typedInput}`,
         toNotify: true,
       });
-      setSelectedBusiness({
-        certified: false,
-        businessName: '',
-        businessTaxId: typedInput,
-      });
-      setSelectedBusinessHistory({
-        certified: false,
-        businessName: '',
-        businessTaxId: typedInput,
-      });
       setActiveStep(3);
     }
+    setSelectedBusiness({
+      certified: false,
+      businessName: '',
+      businessTaxId: typedInput,
+    });
+    setSelectedBusinessHistory({
+      certified: false,
+      businessName: '',
+      businessTaxId: typedInput,
+    });
     setLoading(false);
   };
 


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[PNPG-262] feat: Added resource instead of object with dynamic keys type boolean in check-manager response and used the generated model

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The codegen tool during the conversion from Api 3.0 to swagger 2.0 can't generate correctly the response of check-manager api because expect a schema more specific instead of an object that have dynamic keys of type boolean and, for this reason, the client receive as response always undefined. For fix this, has been introduced a resource specific:

```
"ManagerResultResource": {
      "properties": {
        "result": {
          "description": "Indicate if the manager match with the current",
          "example": false,
          "type": "boolean"
        }
      },
      "title": "ManagerResultResource",
      "type": "object"
    },
    
```
    
With this, the tool can generate correctly the expected response (an object containing a key called result of type boolean) working correcly and, also, the code is more readable.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested aiming environments, the response is correcly retrieved from client that can do the expected logics.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[PNPG-262]: https://pagopa.atlassian.net/browse/PNPG-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ