### PR TITLE
[SELC-6357] Feat: Recover the LR that first onboards the business

### DIFF
--- a/openApi/generated-onboarding/onboarding-swagger20.json
+++ b/openApi/generated-onboarding/onboarding-swagger20.json
@@ -1281,6 +1281,80 @@
         "summary": "onboardingAggregator"
       }
     },
+    "/v1/users/onboarding/{onboardingId}/manager": {
+      "get": {
+        "produces": [
+          "application/json",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "onboardingId",
+            "in": "path",
+            "name": "onboardingId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ManagerInfoResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "user"
+        ],
+        "description": "Returns true if current manager and previous one are the same",
+        "operationId": "checkManager_1",
+        "summary": "getManagerInfo"
+      }
+    },
     "/v1/users/validate": {
       "post": {
         "consumes": [
@@ -3656,6 +3730,24 @@
         "reason"
       ],
       "title": "InvalidParam",
+      "type": "object"
+    },
+    "ManagerInfoResponse": {
+      "properties": {
+        "name": {
+          "description": "User's name",
+          "type": "string"
+        },
+        "surname": {
+          "description": "User's surname",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "surname"
+      ],
+      "title": "ManagerInfoResponse",
       "type": "object"
     },
     "MatchInfoResultResource": {

--- a/openApi/onboarding-api-docs.json
+++ b/openApi/onboarding-api-docs.json
@@ -1,4560 +1,5188 @@
 {
-  "openapi" : "3.0.3",
-  "info" : {
-    "title" : "selc-onboarding",
-    "description" : "Self Care OnBoarding API documentation",
-    "version" : "0.0.1-SNAPSHOT"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "selc-onboarding",
+    "description": "Self Care OnBoarding API documentation",
+    "version": "0.0.1-SNAPSHOT"
   },
-  "servers" : [ {
-    "url" : "{url}:{port}{basePath}",
-    "variables" : {
-      "url" : {
-        "default" : "http://localhost"
-      },
-      "port" : {
-        "default" : "80"
-      },
-      "basePath" : {
-        "default" : ""
+  "servers": [
+    {
+      "url": "{url}:{port}{basePath}",
+      "variables": {
+        "url": {
+          "default": "http://localhost"
+        },
+        "port": {
+          "default": "80"
+        },
+        "basePath": {
+          "default": ""
+        }
       }
     }
-  } ],
-  "tags" : [ {
-    "name" : "institutions",
-    "description" : "Institution operations"
-  }, {
-    "name" : "product",
-    "description" : "Product operations"
-  }, {
-    "name" : "tokens",
-    "description" : "Token V 2 Controller"
-  }, {
-    "name" : "user",
-    "description" : "User Controller"
-  } ],
-  "paths" : {
-    "/v1/institutions" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutions",
-        "description" : "The service retrieves all the onboarded institutions related to the logged user",
-        "operationId" : "getInstitutionsUsingGET",
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+  ],
+  "tags": [
+    {
+      "name": "institutions",
+      "description": "Institution operations"
+    },
+    {
+      "name": "product",
+      "description": "Product operations"
+    },
+    {
+      "name": "tokens",
+      "description": "Token V 2 Controller"
+    },
+    {
+      "name": "user",
+      "description": "User Controller"
+    }
+  ],
+  "paths": {
+    "/v1/institutions": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitutions",
+        "description": "The service retrieves all the onboarded institutions related to the logged user",
+        "operationId": "getInstitutionsUsingGET",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productFilter",
+            "in": "query",
+            "description": "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productFilter",
-          "in" : "query",
-          "description" : "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/InstitutionResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InstitutionResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/company/onboarding" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "onboarding",
-        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
-        "operationId" : "onboardingUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CompanyOnboardingDto"
+    "/v1/institutions/company/onboarding": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboarding",
+        "description": "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId": "onboardingUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyOnboardingDto"
               }
             }
           }
         },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
+        "responses": {
+          "201": {
+            "description": "Created"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/from-infocamere/" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionsFromInfocamere",
-        "description" : "Get Legal Representative's PN PG institution List",
-        "operationId" : "getInstitutionsFromInfocamereUsingGET",
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/from-infocamere/": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitutionsFromInfocamere",
+        "description": "Get Legal Representative's PN PG institution List",
+        "operationId": "getInstitutionsFromInfocamereUsingGET",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionResourceIC"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstitutionResourceIC"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/geographicTaxonomies" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getGeographicTaxonomiesByTaxCodeAndSubunitCode",
-        "description" : "The service retrieve the institution's geographic taxonomy",
-        "operationId" : "getGeographicTaxonomiesByTaxCodeAndSubunitCodeUsingGET",
-        "parameters" : [ {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "Institution's taxCode",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/geographicTaxonomies": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getGeographicTaxonomiesByTaxCodeAndSubunitCode",
+        "description": "The service retrieve the institution's geographic taxonomy",
+        "operationId": "getGeographicTaxonomiesByTaxCodeAndSubunitCodeUsingGET",
+        "parameters": [
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "Institution's taxCode",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "Institution's subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "subunitCode",
-          "in" : "query",
-          "description" : "Institution's subunitCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/GeographicTaxonomyResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeographicTaxonomyResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/onboarding" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "onboarding",
-        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
-        "operationId" : "onboardingUsingPOST_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/OnboardingProductDto"
+    "/v1/institutions/onboarding": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboarding",
+        "description": "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId": "onboardingUsingPOST_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingProductDto"
               }
             }
           }
         },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
+        "responses": {
+          "201": {
+            "description": "Created"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       },
-      "head" : {
-        "tags" : [ "institutions" ],
-        "summary" : "verifyOnboarding",
-        "description" : "Checks if the specified institution has been onboarded on the specified product.",
-        "operationId" : "verifyOnboardingUsingHEAD",
-        "parameters" : [ {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "Institution's taxCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "subunitCode",
-          "in" : "query",
-          "description" : "Institution's subunitCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "origin",
-          "in" : "query",
-          "description" : "Institution data origin",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "originId",
-          "in" : "query",
-          "description" : "Institution's details origin Id",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "vatNumber",
-          "in" : "query",
-          "description" : "Institution's VAT number",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "verifyType",
-          "in" : "query",
-          "description" : "Onboarding verification method type",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "EXTERNAL", "INTERNAL" ]
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+      "head": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "verifyOnboarding",
+        "description": "Checks if the specified institution has been onboarded on the specified product.",
+        "operationId": "verifyOnboardingUsingHEAD",
+        "parameters": [
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "Institution's taxCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "Institution's subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "query",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "query",
+            "description": "Institution data origin",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "originId",
+            "in": "query",
+            "description": "Institution's details origin Id",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vatNumber",
+            "in": "query",
+            "description": "Institution's VAT number",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verifyType",
+            "in": "query",
+            "description": "Onboarding verification method type",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "EXTERNAL",
+                "INTERNAL"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/onboarding/" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionOnboardingInfoById",
-        "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal Id",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/onboarding/": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitutionOnboardingInfoById",
+        "description": "The service retrieves the institutions Manager and institution informations",
+        "operationId": "getInstitutionOnboardingInfoUsingGET",
+        "parameters": [
+          {
+            "name": "institutionId",
+            "in": "query",
+            "description": "Institution's unique internal Id",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "query",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionOnboardingInfoResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstitutionOnboardingInfoResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/verification/legal-address" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "postVerificationLegalAddress",
-        "description" : "Get legal address by business tax id",
-        "operationId" : "postVerificationLegalAddressUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/VerificationLegalAddressRequest"
+    "/v1/institutions/verification/legal-address": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "postVerificationLegalAddress",
+        "description": "Get legal address by business tax id",
+        "operationId": "postVerificationLegalAddressUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerificationLegalAddressRequest"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionLegalAddressResource"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstitutionLegalAddressResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/verification/match" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "postVerificationMatch",
-        "description" : "MatchLegal Representative and inserted Institution by querying on Agenzia delle Entrate",
-        "operationId" : "postVerificationMatchUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/VerificationMatchRequest"
+    "/v1/institutions/verification/match": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "postVerificationMatch",
+        "description": "MatchLegal Representative and inserted Institution by querying on Agenzia delle Entrate",
+        "operationId": "postVerificationMatchUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerificationMatchRequest"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/MatchInfoResultResource"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchInfoResultResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/{externalInstitutionId}/geographicTaxonomy" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionGeographicTaxonomy",
-        "description" : "The service retrieve the institution's geographic taxonomy",
-        "operationId" : "getInstitutionGeographicTaxonomyUsingGET",
-        "parameters" : [ {
-          "name" : "externalInstitutionId",
-          "in" : "path",
-          "description" : "Institution's unique external identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/{externalInstitutionId}/geographicTaxonomy": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitutionGeographicTaxonomy",
+        "description": "The service retrieve the institution's geographic taxonomy",
+        "operationId": "getInstitutionGeographicTaxonomyUsingGET",
+        "parameters": [
+          {
+            "name": "externalInstitutionId",
+            "in": "path",
+            "description": "Institution's unique external identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/GeographicTaxonomyResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeographicTaxonomyResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/{externalInstitutionId}/products/{productId}" : {
-      "head" : {
-        "tags" : [ "institutions" ],
-        "summary" : "verifyOnboarding",
-        "description" : "Checks if the specified institution has been onboarded on the specified product.",
-        "operationId" : "verifyOnboardingUsingHEAD_1",
-        "parameters" : [ {
-          "name" : "externalInstitutionId",
-          "in" : "path",
-          "description" : "Institution's unique external identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/{externalInstitutionId}/products/{productId}": {
+      "head": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "verifyOnboarding",
+        "description": "Checks if the specified institution has been onboarded on the specified product.",
+        "operationId": "verifyOnboardingUsingHEAD_1",
+        "parameters": [
+          {
+            "name": "externalInstitutionId",
+            "in": "path",
+            "description": "Institution's unique external identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/institutions/{externalInstitutionId}/products/{productId}/onboarded-institution-info" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionOnboardingInfo",
-        "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoUsingGET_1",
-        "parameters" : [ {
-          "name" : "externalInstitutionId",
-          "in" : "path",
-          "description" : "Institution's unique external identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v1/institutions/{externalInstitutionId}/products/{productId}/onboarded-institution-info": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitutionOnboardingInfo",
+        "description": "The service retrieves the institutions Manager and institution informations",
+        "operationId": "getInstitutionOnboardingInfoUsingGET_1",
+        "parameters": [
+          {
+            "name": "externalInstitutionId",
+            "in": "path",
+            "description": "Institution's unique external identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionOnboardingInfoResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstitutionOnboardingInfoResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "deprecated" : true,
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "deprecated": true,
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitution",
-        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
-        "operationId" : "v2GetInstitutionByFilters",
-        "parameters" : [ {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v2/institutions": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getInstitution",
+        "description": "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId": "v2GetInstitutionByFilters",
+        "parameters": [
+          {
+            "name": "productId",
+            "in": "query",
+            "description": "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "Institution's taxCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "query",
+            "description": "Institution data origin",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "originId",
+            "in": "query",
+            "description": "Institution's details origin Id",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "Institution's subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "Institution's taxCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "origin",
-          "in" : "query",
-          "description" : "Institution data origin",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "originId",
-          "in" : "query",
-          "description" : "Institution's details origin Id",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "subunitCode",
-          "in" : "query",
-          "description" : "Institution's subunitCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/InstitutionResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InstitutionResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/company/onboarding" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "onboarding",
-        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
-        "operationId" : "onboardingUsingPOST_2",
-        "parameters" : [ {
-          "name" : "name",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CompanyOnboardingDto"
-              }
+    "/v2/institutions/company/onboarding": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboarding",
+        "description": "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId": "onboardingUsingPOST_2",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
             }
           }
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyOnboardingDto"
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/company/verify-manager" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "verifyManager",
-        "description" : "The service allows to verify the legal representative on external registries and retrieve the company name",
-        "operationId" : "verifyManagerUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/VerifyManagerRequest"
+    "/v2/institutions/company/verify-manager": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "verifyManager",
+        "description": "The service allows to verify the legal representative on external registries and retrieve the company name",
+        "operationId": "verifyManagerUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyManagerRequest"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/VerifyManagerResponse"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyManagerResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/onboarding" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "onboarding",
-        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
-        "operationId" : "onboardingUsingPOST_3",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/OnboardingProductDto"
+    "/v2/institutions/onboarding": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboarding",
+        "description": "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId": "onboardingUsingPOST_3",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingProductDto"
               }
             }
           }
         },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
+        "responses": {
+          "201": {
+            "description": "Created"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/onboarding/active" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getActiveOnboarding",
-        "description" : "The service retrieves the active onboarding information for a given tax code and product ID",
-        "operationId" : "getActiveOnboardingUsingGET",
-        "parameters" : [ {
-          "name" : "taxCode",
-          "in" : "query",
-          "description" : "taxCode",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v2/institutions/onboarding/active": {
+      "get": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "getActiveOnboarding",
+        "description": "The service retrieves the active onboarding information for a given tax code and product ID",
+        "operationId": "getActiveOnboardingUsingGET",
+        "parameters": [
+          {
+            "name": "taxCode",
+            "in": "query",
+            "description": "taxCode",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "query",
+            "description": "productId",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subunitCode",
+            "in": "query",
+            "description": "subunitCode",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "productId",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "subunitCode",
-          "in" : "query",
-          "description" : "subunitCode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/InstitutionOnboardingResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InstitutionOnboardingResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/onboarding/recipientCode/verification" : {
-      "get" : {
-        "tags" : [ "billing-portal", "institutions" ],
-        "summary" : "checkRecipientCode",
-        "description" : "The service allows to verify if recipientCode is valid or not",
-        "operationId" : "checkRecipientCodeUsingGET",
-        "parameters" : [ {
-          "name" : "originId",
-          "in" : "query",
-          "description" : "originId",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
+    "/v2/institutions/onboarding/recipientCode/verification": {
+      "get": {
+        "tags": [
+          "billing-portal",
+          "institutions"
+        ],
+        "summary": "checkRecipientCode",
+        "description": "The service allows to verify if recipientCode is valid or not",
+        "operationId": "checkRecipientCodeUsingGET",
+        "parameters": [
+          {
+            "name": "originId",
+            "in": "query",
+            "description": "originId",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "recipientCode",
+            "in": "query",
+            "description": "recipientCode",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "recipientCode",
-          "in" : "query",
-          "description" : "recipientCode",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "enum" : [ "ACCEPTED", "DENIED_NO_ASSOCIATION", "DENIED_NO_BILLING" ]
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "ACCEPTED",
+                    "DENIED_NO_ASSOCIATION",
+                    "DENIED_NO_BILLING"
+                  ]
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/institutions/onboarding/users/pg" : {
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "onboardingUsers",
-        "description" : "The service allows the onboarding of Users to a PG Institution",
-        "operationId" : "onboardingUsersUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CompanyOnboardingUserDto"
+    "/v2/institutions/onboarding/users/pg": {
+      "post": {
+        "tags": [
+          "institutions"
+        ],
+        "summary": "onboardingUsers",
+        "description": "The service allows the onboarding of Users to a PG Institution",
+        "operationId": "onboardingUsersUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyOnboardingUserDto"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK"
+        "responses": {
+          "200": {
+            "description": "OK"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/product/{id}" : {
-      "get" : {
-        "tags" : [ "product" ],
-        "summary" : "getProduct",
-        "description" : "The service retrieves the product given its internal id",
-        "operationId" : "getProductUsingGET",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v1/product/{id}": {
+      "get": {
+        "tags": [
+          "product"
+        ],
+        "summary": "getProduct",
+        "description": "The service retrieves the product given its internal id",
+        "operationId": "getProductUsingGET",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "institutionType",
+            "in": "query",
+            "description": "Institution's type",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AS",
+                "CON",
+                "GPU",
+                "GSP",
+                "PA",
+                "PG",
+                "PRV",
+                "PSP",
+                "PT",
+                "REC",
+                "SA",
+                "SCP"
+              ]
+            }
           }
-        }, {
-          "name" : "institutionType",
-          "in" : "query",
-          "description" : "Institution's type",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProductResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/products" : {
-      "get" : {
-        "tags" : [ "product" ],
-        "summary" : "getProducts",
-        "description" : "The service retrieves all products",
-        "operationId" : "getProducts",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ProductResource"
+    "/v1/products": {
+      "get": {
+        "tags": [
+          "product"
+        ],
+        "summary": "getProducts",
+        "description": "The service retrieves all products",
+        "operationId": "getProducts",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProductResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/products/admin" : {
-      "get" : {
-        "tags" : [ "product" ],
-        "summary" : "getProductsAdmin",
-        "description" : "The service retrieves all products for the addition administration functionality",
-        "operationId" : "getProductsAdmin",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ProductResource"
+    "/v1/products/admin": {
+      "get": {
+        "tags": [
+          "product"
+        ],
+        "summary": "getProductsAdmin",
+        "description": "The service retrieves all products for the addition administration functionality",
+        "operationId": "getProductsAdmin",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProductResource"
                   }
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}" : {
-      "get" : {
-        "tags" : [ "tokens" ],
-        "summary" : "retrieveOnboardingRequest",
-        "description" : "Service to retrieve a specific onboarding request",
-        "operationId" : "retrieveOnboardingRequestUsingGET",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "retrieveOnboardingRequest",
+        "description": "Service to retrieve a specific onboarding request",
+        "operationId": "retrieveOnboardingRequestUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/OnboardingRequestResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingRequestResource"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/approve" : {
-      "post" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Service to approve a specific onboarding request",
-        "description" : "Service to approve a specific onboarding request",
-        "operationId" : "approveOnboardingUsingPOST",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/approve": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Service to approve a specific onboarding request",
+        "description": "Service to approve a specific onboarding request",
+        "operationId": "approveOnboardingUsingPOST",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/attachment" : {
-      "get" : {
-        "tags" : [ "tokens" ],
-        "summary" : "getAttachment",
-        "description" : "Service to download a specific onboarding attachment",
-        "operationId" : "getAttachmentUsingGET",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/attachment": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "getAttachment",
+        "description": "Service to download a specific onboarding attachment",
+        "operationId": "getAttachmentUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Onboarding's attachment name",
+            "required": true,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "name",
-          "in" : "query",
-          "description" : "Onboarding's attachment name",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/octet-stream" : {
-                "schema" : {
-                  "type" : "string",
-                  "format" : "byte"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/complete" : {
-      "post" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Complete an onboarding request",
-        "description" : "Complete an onboarding request",
-        "operationId" : "completeUsingPOST",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/complete": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Complete an onboarding request",
+        "description": "Complete an onboarding request",
+        "operationId": "completeUsingPOST",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "multipart/form-data" : {
-              "schema" : {
-                "required" : [ "contract" ],
-                "type" : "object",
-                "properties" : {
-                  "contract" : {
-                    "type" : "string",
-                    "description" : "contract",
-                    "format" : "binary"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "contract"
+                ],
+                "type": "object",
+                "properties": {
+                  "contract": {
+                    "type": "string",
+                    "description": "contract",
+                    "format": "binary"
                   }
                 }
               }
             }
           }
         },
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+        "responses": {
+          "204": {
+            "description": "No Content"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Complete an onboarding request",
-        "description" : "Complete an onboarding request",
-        "operationId" : "deleteUsingDELETE",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Contract's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+      "delete": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Complete an onboarding request",
+        "description": "Complete an onboarding request",
+        "operationId": "deleteUsingDELETE",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Contract's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/completeOnboardingUsers" : {
-      "post" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Complete an onboarding users request",
-        "description" : "Complete an onboarding users request",
-        "operationId" : "completeOnboardingUsersUsingPOST",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/completeOnboardingUsers": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Complete an onboarding users request",
+        "description": "Complete an onboarding users request",
+        "operationId": "completeOnboardingUsersUsingPOST",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "multipart/form-data" : {
-              "schema" : {
-                "required" : [ "contract" ],
-                "type" : "object",
-                "properties" : {
-                  "contract" : {
-                    "type" : "string",
-                    "description" : "contract",
-                    "format" : "binary"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "contract"
+                ],
+                "type": "object",
+                "properties": {
+                  "contract": {
+                    "type": "string",
+                    "description": "contract",
+                    "format": "binary"
                   }
                 }
               }
             }
           }
         },
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+        "responses": {
+          "204": {
+            "description": "No Content"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/contract" : {
-      "get" : {
-        "tags" : [ "tokens" ],
-        "summary" : "getContract",
-        "description" : "Service to download a specific onboarding contract",
-        "operationId" : "getContractUsingGET",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/contract": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "getContract",
+        "description": "Service to download a specific onboarding contract",
+        "operationId": "getContractUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/octet-stream" : {
-                "schema" : {
-                  "type" : "string",
-                  "format" : "byte"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/products/{productId}/aggregates-csv" : {
-      "get" : {
-        "tags" : [ "tokens" ],
-        "summary" : "getAggregatesCsv",
-        "description" : "Service to download a specific onboarding aggregates csv",
-        "operationId" : "getAggregatesCsvUsingGET",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/products/{productId}/aggregates-csv": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "getAggregatesCsv",
+        "description": "Service to download a specific onboarding aggregates csv",
+        "operationId": "getAggregatesCsvUsingGET",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Product's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/octet-stream" : {
-                "schema" : {
-                  "type" : "string",
-                  "format" : "byte"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/reject" : {
-      "post" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Service to reject a specific onboarding request",
-        "operationId" : "rejectOnboardingUsingPOST",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ReasonForRejectDto"
-              }
+    "/v2/tokens/{onboardingId}/reject": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Service to reject a specific onboarding request",
+        "operationId": "rejectOnboardingUsingPOST",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
             }
           }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReasonForRejectDto"
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v2/tokens/{onboardingId}/verify" : {
-      "post" : {
-        "tags" : [ "tokens" ],
-        "summary" : "Verify if the token is already consumed",
-        "description" : "Verify if the token is already consumed",
-        "operationId" : "verifyOnboardingUsingPOST",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "description" : "Onboarding's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
+    "/v2/tokens/{onboardingId}/verify": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Verify if the token is already consumed",
+        "description": "Verify if the token is already consumed",
+        "operationId": "verifyOnboardingUsingPOST",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "Onboarding's unique identifier",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/OnboardingVerify"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnboardingVerify"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/users/check-manager" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "checkManager",
-        "description" : "Returns true if current manager and previous one are the same",
-        "operationId" : "checkManager",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/OnboardingUserDto"
+    "/v1/users/check-manager": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "checkManager",
+        "description": "Returns true if current manager and previous one are the same",
+        "operationId": "checkManager",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingUserDto"
               }
             }
           }
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/CheckManagerResponse"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckManagerResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/users/onboarding" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "onboarding",
-        "description" : "The service allows the onboarding of Users",
-        "operationId" : "onboardingUsingPOST_4",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/OnboardingUserDto"
+    "/v1/users/onboarding": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "onboarding",
+        "description": "The service allows the onboarding of Users",
+        "operationId": "onboardingUsingPOST_4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingUserDto"
               }
             }
           }
         },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
+        "responses": {
+          "201": {
+            "description": "Created"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/users/onboarding/aggregator" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "onboardingAggregator",
-        "description" : "The service allows the onboarding of Users for aggregators",
-        "operationId" : "onboardingAggregatorUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/OnboardingUserDto"
+    "/v1/users/onboarding/aggregator": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "onboardingAggregator",
+        "description": "The service allows the onboarding of Users for aggregators",
+        "operationId": "onboardingAggregatorUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingUserDto"
               }
             }
           }
         },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
+        "responses": {
+          "201": {
+            "description": "Created"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     },
-    "/v1/users/validate" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "validate",
-        "description" : "Check if requested user data are valid",
-        "operationId" : "validateUsingPOST",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UserDataValidationDto"
+    "/v1/users/onboarding/{onboardingId}/manager": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "getManagerInfo",
+        "description": "Returns true if current manager and previous one are the same",
+        "operationId": "checkManager_1",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "onboardingId",
+            "in": "path",
+            "description": "onboardingId",
+            "required": true,
+            "style": "simple",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
               }
             }
           }
         },
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/users/validate": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "validate",
+        "description": "Check if requested user data are valid",
+        "operationId": "validateUsingPOST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserDataValidationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ]
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "AdditionalInformations" : {
-        "title" : "AdditionalInformations",
-        "type" : "object",
-        "properties" : {
-          "agentOfPublicService" : {
-            "type" : "boolean",
-            "description" : "The institution is an agent of a public service",
-            "example" : false
+  "components": {
+    "schemas": {
+      "AdditionalInformations": {
+        "title": "AdditionalInformations",
+        "type": "object",
+        "properties": {
+          "agentOfPublicService": {
+            "type": "boolean",
+            "description": "The institution is an agent of a public service",
+            "example": false
           },
-          "agentOfPublicServiceNote" : {
-            "type" : "string",
-            "description" : "agentOfPublicService Note"
+          "agentOfPublicServiceNote": {
+            "type": "string",
+            "description": "agentOfPublicService Note"
           },
-          "belongRegulatedMarket" : {
-            "type" : "boolean",
-            "description" : "The institution belongs to a regulated market",
-            "example" : false
+          "belongRegulatedMarket": {
+            "type": "boolean",
+            "description": "The institution belongs to a regulated market",
+            "example": false
           },
-          "establishedByRegulatoryProvision" : {
-            "type" : "boolean",
-            "description" : "The institution is a company established by a regulatory provision",
-            "example" : false
+          "establishedByRegulatoryProvision": {
+            "type": "boolean",
+            "description": "The institution is a company established by a regulatory provision",
+            "example": false
           },
-          "establishedByRegulatoryProvisionNote" : {
-            "type" : "string",
-            "description" : "establishedByRegulatoryProvision Note"
+          "establishedByRegulatoryProvisionNote": {
+            "type": "string",
+            "description": "establishedByRegulatoryProvision Note"
           },
-          "ipa" : {
-            "type" : "boolean",
-            "description" : "The institution is registered on IPA",
-            "example" : false
+          "ipa": {
+            "type": "boolean",
+            "description": "The institution is registered on IPA",
+            "example": false
           },
-          "ipaCode" : {
-            "type" : "string",
-            "description" : "IPA code"
+          "ipaCode": {
+            "type": "string",
+            "description": "IPA code"
           },
-          "otherNote" : {
-            "type" : "string",
-            "description" : "Other note"
+          "otherNote": {
+            "type": "string",
+            "description": "Other note"
           },
-          "regulatedMarketNote" : {
-            "type" : "string",
-            "description" : "regulatedMarket Note"
+          "regulatedMarketNote": {
+            "type": "string",
+            "description": "regulatedMarket Note"
           }
         }
       },
-      "AdditionalInformationsDto" : {
-        "title" : "AdditionalInformationsDto",
-        "type" : "object",
-        "properties" : {
-          "agentOfPublicService" : {
-            "type" : "boolean",
-            "description" : "The institution is an agent of a public service",
-            "example" : false
+      "AdditionalInformationsDto": {
+        "title": "AdditionalInformationsDto",
+        "type": "object",
+        "properties": {
+          "agentOfPublicService": {
+            "type": "boolean",
+            "description": "The institution is an agent of a public service",
+            "example": false
           },
-          "agentOfPublicServiceNote" : {
-            "type" : "string",
-            "description" : "agentOfPublicService Note"
+          "agentOfPublicServiceNote": {
+            "type": "string",
+            "description": "agentOfPublicService Note"
           },
-          "belongRegulatedMarket" : {
-            "type" : "boolean",
-            "description" : "The institution belongs to a regulated market",
-            "example" : false
+          "belongRegulatedMarket": {
+            "type": "boolean",
+            "description": "The institution belongs to a regulated market",
+            "example": false
           },
-          "establishedByRegulatoryProvision" : {
-            "type" : "boolean",
-            "description" : "The institution is a company established by a regulatory provision",
-            "example" : false
+          "establishedByRegulatoryProvision": {
+            "type": "boolean",
+            "description": "The institution is a company established by a regulatory provision",
+            "example": false
           },
-          "establishedByRegulatoryProvisionNote" : {
-            "type" : "string",
-            "description" : "establishedByRegulatoryProvision Note"
+          "establishedByRegulatoryProvisionNote": {
+            "type": "string",
+            "description": "establishedByRegulatoryProvision Note"
           },
-          "ipa" : {
-            "type" : "boolean",
-            "description" : "The institution is registered on IPA",
-            "example" : false
+          "ipa": {
+            "type": "boolean",
+            "description": "The institution is registered on IPA",
+            "example": false
           },
-          "ipaCode" : {
-            "type" : "string",
-            "description" : "IPA code"
+          "ipaCode": {
+            "type": "string",
+            "description": "IPA code"
           },
-          "otherNote" : {
-            "type" : "string",
-            "description" : "Other note"
+          "otherNote": {
+            "type": "string",
+            "description": "Other note"
           },
-          "regulatedMarketNote" : {
-            "type" : "string",
-            "description" : "regulatedMarket Note"
+          "regulatedMarketNote": {
+            "type": "string",
+            "description": "regulatedMarket Note"
           }
         }
       },
-      "AggregateInstitution" : {
-        "title" : "AggregateInstitution",
-        "required" : [ "description", "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string"
+      "AggregateInstitution": {
+        "title": "AggregateInstitution",
+        "required": [
+          "description",
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
           },
-          "city" : {
-            "type" : "string"
+          "city": {
+            "type": "string"
           },
-          "county" : {
-            "type" : "string"
+          "county": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "digitalAddress" : {
-            "type" : "string"
+          "digitalAddress": {
+            "type": "string"
           },
-          "geographicTaxonomies" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/GeographicTaxonomyDto"
+          "geographicTaxonomies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeographicTaxonomyDto"
             }
           },
-          "iban" : {
-            "type" : "string"
+          "iban": {
+            "type": "string"
           },
-          "origin" : {
-            "type" : "string",
-            "enum" : [ "ADE", "ANAC", "INFOCAMERE", "IPA", "IVASS", "MOCK", "PDND_INFOCAMERE", "SELC", "UNKNOWN" ]
+          "origin": {
+            "type": "string",
+            "enum": [
+              "ADE",
+              "ANAC",
+              "INFOCAMERE",
+              "IPA",
+              "IVASS",
+              "MOCK",
+              "PDND_INFOCAMERE",
+              "SELC",
+              "UNKNOWN"
+            ]
           },
-          "originId" : {
-            "type" : "string"
+          "originId": {
+            "type": "string"
           },
-          "parentDescription" : {
-            "type" : "string"
+          "parentDescription": {
+            "type": "string"
           },
-          "recipientCode" : {
-            "type" : "string"
+          "recipientCode": {
+            "type": "string"
           },
-          "service" : {
-            "type" : "string"
+          "service": {
+            "type": "string"
           },
-          "subunitCode" : {
-            "type" : "string"
+          "subunitCode": {
+            "type": "string"
           },
-          "subunitType" : {
-            "type" : "string"
+          "subunitType": {
+            "type": "string"
           },
-          "syncAsyncMode" : {
-            "type" : "string"
+          "syncAsyncMode": {
+            "type": "string"
           },
-          "taxCode" : {
-            "type" : "string"
+          "taxCode": {
+            "type": "string"
           },
-          "taxCodePT" : {
-            "type" : "string"
+          "taxCodePT": {
+            "type": "string"
           },
-          "users" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDto"
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserDto"
             }
           },
-          "vatNumber" : {
-            "type" : "string"
+          "vatNumber": {
+            "type": "string"
           },
-          "zipCode" : {
-            "type" : "string"
+          "zipCode": {
+            "type": "string"
           }
         }
       },
-      "AggregateResult" : {
-        "title" : "AggregateResult",
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string"
+      "AggregateResult": {
+        "title": "AggregateResult",
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
           },
-          "city" : {
-            "type" : "string"
+          "city": {
+            "type": "string"
           },
-          "county" : {
-            "type" : "string"
+          "county": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "digitalAddress" : {
-            "type" : "string"
+          "digitalAddress": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string"
+          "iban": {
+            "type": "string"
           },
-          "origin" : {
-            "type" : "string"
+          "origin": {
+            "type": "string"
           },
-          "originId" : {
-            "type" : "string"
+          "originId": {
+            "type": "string"
           },
-          "parentDescription" : {
-            "type" : "string"
+          "parentDescription": {
+            "type": "string"
           },
-          "recipientCode" : {
-            "type" : "string"
+          "recipientCode": {
+            "type": "string"
           },
-          "service" : {
-            "type" : "string"
+          "service": {
+            "type": "string"
           },
-          "subunitCode" : {
-            "type" : "string"
+          "subunitCode": {
+            "type": "string"
           },
-          "subunitType" : {
-            "type" : "string"
+          "subunitType": {
+            "type": "string"
           },
-          "syncAsyncMode" : {
-            "type" : "string"
+          "syncAsyncMode": {
+            "type": "string"
           },
-          "taxCode" : {
-            "type" : "string"
+          "taxCode": {
+            "type": "string"
           },
-          "taxCodePT" : {
-            "type" : "string"
+          "taxCodePT": {
+            "type": "string"
           },
-          "users" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AggregateUserResult"
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AggregateUserResult"
             }
           },
-          "vatNumber" : {
-            "type" : "string"
+          "vatNumber": {
+            "type": "string"
           },
-          "zipCode" : {
-            "type" : "string"
+          "zipCode": {
+            "type": "string"
           }
         }
       },
-      "AggregateUserResult" : {
-        "title" : "AggregateUserResult",
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string"
+      "AggregateUserResult": {
+        "title": "AggregateUserResult",
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
           },
-          "name" : {
-            "type" : "string"
+          "name": {
+            "type": "string"
           },
-          "role" : {
-            "type" : "string"
+          "role": {
+            "type": "string"
           },
-          "surname" : {
-            "type" : "string"
+          "surname": {
+            "type": "string"
           },
-          "taxCode" : {
-            "type" : "string"
+          "taxCode": {
+            "type": "string"
           }
         }
       },
-      "AssistanceContactsDto" : {
-        "title" : "AssistanceContactsDto",
-        "type" : "object",
-        "properties" : {
-          "supportEmail" : {
-            "type" : "string",
-            "description" : "Institution's support email contact",
-            "format" : "email",
-            "example" : "email@example.com"
+      "AssistanceContactsDto": {
+        "title": "AssistanceContactsDto",
+        "type": "object",
+        "properties": {
+          "supportEmail": {
+            "type": "string",
+            "description": "Institution's support email contact",
+            "format": "email",
+            "example": "email@example.com"
           },
-          "supportPhone" : {
-            "type" : "string",
-            "description" : "Institution's support phone contact"
+          "supportPhone": {
+            "type": "string",
+            "description": "Institution's support phone contact"
           }
         }
       },
-      "AssistanceContactsResource" : {
-        "title" : "AssistanceContactsResource",
-        "type" : "object",
-        "properties" : {
-          "supportEmail" : {
-            "type" : "string",
-            "description" : "Institution's support email contact"
+      "AssistanceContactsResource": {
+        "title": "AssistanceContactsResource",
+        "type": "object",
+        "properties": {
+          "supportEmail": {
+            "type": "string",
+            "description": "Institution's support email contact"
           },
-          "supportPhone" : {
-            "type" : "string",
-            "description" : "Institution's support phone contact"
+          "supportPhone": {
+            "type": "string",
+            "description": "Institution's support phone contact"
           }
         }
       },
-      "Billing" : {
-        "title" : "Billing",
-        "type" : "object",
-        "properties" : {
-          "publicServices" : {
-            "type" : "boolean"
+      "Billing": {
+        "title": "Billing",
+        "type": "object",
+        "properties": {
+          "publicServices": {
+            "type": "boolean"
           },
-          "recipientCode" : {
-            "type" : "string"
+          "recipientCode": {
+            "type": "string"
           },
-          "taxCodeInvoicing" : {
-            "type" : "string"
+          "taxCodeInvoicing": {
+            "type": "string"
           },
-          "vatNumber" : {
-            "type" : "string"
+          "vatNumber": {
+            "type": "string"
           }
         }
       },
-      "BillingDataDto" : {
-        "title" : "BillingDataDto",
-        "required" : [ "businessName", "digitalAddress", "registeredOffice" ],
-        "type" : "object",
-        "properties" : {
-          "businessName" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
+      "BillingDataDto": {
+        "title": "BillingDataDto",
+        "required": [
+          "businessName",
+          "digitalAddress",
+          "registeredOffice"
+        ],
+        "type": "object",
+        "properties": {
+          "businessName": {
+            "type": "string",
+            "description": "Institution's legal name"
           },
-          "certified" : {
-            "type" : "boolean",
-            "description" : "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
-            "example" : false
+          "certified": {
+            "type": "boolean",
+            "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+            "example": false
           },
-          "digitalAddress" : {
-            "type" : "string",
-            "description" : "Institution's digitalAddress"
+          "digitalAddress": {
+            "type": "string",
+            "description": "Institution's digitalAddress"
           },
-          "publicServices" : {
-            "type" : "boolean",
-            "description" : "Institution's service type",
-            "example" : false
+          "publicServices": {
+            "type": "boolean",
+            "description": "Institution's service type",
+            "example": false
           },
-          "recipientCode" : {
-            "type" : "string",
-            "description" : "Billing recipient code, not required only for institutionType SA"
+          "recipientCode": {
+            "type": "string",
+            "description": "Billing recipient code, not required only for institutionType SA"
           },
-          "registeredOffice" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
+          "registeredOffice": {
+            "type": "string",
+            "description": "Institution's physical address"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           },
-          "taxCodeInvoicing" : {
-            "type" : "string",
-            "description" : "Institution's taxCodeInvoicing for electronic invoicing"
+          "taxCodeInvoicing": {
+            "type": "string",
+            "description": "Institution's taxCodeInvoicing for electronic invoicing"
           },
-          "vatNumber" : {
-            "type" : "string",
-            "description" : "Institution's VAT number"
+          "vatNumber": {
+            "type": "string",
+            "description": "Institution's VAT number"
           },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
+          "zipCode": {
+            "type": "string",
+            "description": "Institution's zipCode"
           }
         }
       },
-      "BillingDataResponseDto" : {
-        "title" : "BillingDataResponseDto",
-        "type" : "object",
-        "properties" : {
-          "businessName" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
+      "BillingDataResponseDto": {
+        "title": "BillingDataResponseDto",
+        "type": "object",
+        "properties": {
+          "businessName": {
+            "type": "string",
+            "description": "Institution's legal name"
           },
-          "certified" : {
-            "type" : "boolean",
-            "description" : "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
-            "example" : false
+          "certified": {
+            "type": "boolean",
+            "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+            "example": false
           },
-          "digitalAddress" : {
-            "type" : "string",
-            "description" : "Institution's digitalAddress"
+          "digitalAddress": {
+            "type": "string",
+            "description": "Institution's digitalAddress"
           },
-          "publicServices" : {
-            "type" : "boolean",
-            "description" : "Institution's service type",
-            "example" : false
+          "publicServices": {
+            "type": "boolean",
+            "description": "Institution's service type",
+            "example": false
           },
-          "recipientCode" : {
-            "type" : "string",
-            "description" : "Billing recipient code, not required only for institutionType SA"
+          "recipientCode": {
+            "type": "string",
+            "description": "Billing recipient code, not required only for institutionType SA"
           },
-          "registeredOffice" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
+          "registeredOffice": {
+            "type": "string",
+            "description": "Institution's physical address"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           },
-          "vatNumber" : {
-            "type" : "string",
-            "description" : "Institution's VAT number"
+          "vatNumber": {
+            "type": "string",
+            "description": "Institution's VAT number"
           },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
+          "zipCode": {
+            "type": "string",
+            "description": "Institution's zipCode"
           }
         }
       },
-      "BusinessResourceIC" : {
-        "title" : "BusinessResourceIC",
-        "type" : "object",
-        "properties" : {
-          "businessName" : {
-            "type" : "string",
-            "description" : "Legal Representative's institutions name"
+      "BusinessResourceIC": {
+        "title": "BusinessResourceIC",
+        "type": "object",
+        "properties": {
+          "businessName": {
+            "type": "string",
+            "description": "Legal Representative's institutions name"
           },
-          "businessTaxId" : {
-            "type" : "string",
-            "description" : "Legal Representative's institutions tax ID"
+          "businessTaxId": {
+            "type": "string",
+            "description": "Legal Representative's institutions tax ID"
           }
         }
       },
-      "CheckManagerResponse" : {
-        "title" : "CheckManagerResponse",
-        "required" : [ "result" ],
-        "type" : "object",
-        "properties" : {
-          "result" : {
-            "type" : "boolean",
-            "description" : "Is the given user manager of the institution",
-            "example" : false
+      "CheckManagerResponse": {
+        "title": "CheckManagerResponse",
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean",
+            "description": "Is the given user manager of the institution",
+            "example": false
           }
         }
       },
-      "CompanyBillingDataDto" : {
-        "title" : "CompanyBillingDataDto",
-        "required" : [ "businessName", "certified", "digitalAddress", "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "businessName" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
+      "CompanyBillingDataDto": {
+        "title": "CompanyBillingDataDto",
+        "required": [
+          "businessName",
+          "certified",
+          "digitalAddress",
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "businessName": {
+            "type": "string",
+            "description": "Institution's legal name"
           },
-          "certified" : {
-            "type" : "boolean",
-            "description" : "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
-            "example" : false
+          "certified": {
+            "type": "boolean",
+            "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+            "example": false
           },
-          "digitalAddress" : {
-            "type" : "string",
-            "description" : "Institution's digitalAddress"
+          "digitalAddress": {
+            "type": "string",
+            "description": "Institution's digitalAddress"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           }
         }
       },
-      "CompanyInformationsDto" : {
-        "title" : "CompanyInformationsDto",
-        "type" : "object",
-        "properties" : {
-          "businessRegisterPlace" : {
-            "type" : "string",
-            "description" : "Institution's business register place"
+      "CompanyInformationsDto": {
+        "title": "CompanyInformationsDto",
+        "type": "object",
+        "properties": {
+          "businessRegisterPlace": {
+            "type": "string",
+            "description": "Institution's business register place"
           },
-          "rea" : {
-            "type" : "string",
-            "description" : "Institution's REA"
+          "rea": {
+            "type": "string",
+            "description": "Institution's REA"
           },
-          "shareCapital" : {
-            "type" : "string",
-            "description" : "Institution's share capital value"
+          "shareCapital": {
+            "type": "string",
+            "description": "Institution's share capital value"
           }
         }
       },
-      "CompanyInformationsResource" : {
-        "title" : "CompanyInformationsResource",
-        "type" : "object",
-        "properties" : {
-          "businessRegisterPlace" : {
-            "type" : "string",
-            "description" : "Institution's business register place"
+      "CompanyInformationsResource": {
+        "title": "CompanyInformationsResource",
+        "type": "object",
+        "properties": {
+          "businessRegisterPlace": {
+            "type": "string",
+            "description": "Institution's business register place"
           },
-          "rea" : {
-            "type" : "string",
-            "description" : "Institution's REA"
+          "rea": {
+            "type": "string",
+            "description": "Institution's REA"
           },
-          "shareCapital" : {
-            "type" : "string",
-            "description" : "Institution's share capital value"
+          "shareCapital": {
+            "type": "string",
+            "description": "Institution's share capital value"
           }
         }
       },
-      "CompanyOnboardingDto" : {
-        "title" : "CompanyOnboardingDto",
-        "required" : [ "billingData", "institutionType", "productId", "taxCode", "users" ],
-        "type" : "object",
-        "properties" : {
-          "billingData" : {
-            "description" : "Institution's billing information",
-            "$ref" : "#/components/schemas/CompanyBillingDataDto"
+      "CompanyOnboardingDto": {
+        "title": "CompanyOnboardingDto",
+        "required": [
+          "billingData",
+          "institutionType",
+          "productId",
+          "taxCode",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "billingData": {
+            "description": "Institution's billing information",
+            "$ref": "#/components/schemas/CompanyBillingDataDto"
           },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           },
-          "users" : {
-            "type" : "array",
-            "description" : "List of onboarding users",
-            "items" : {
-              "$ref" : "#/components/schemas/CompanyUserDto"
-            }
-          }
-        }
-      },
-      "CompanyOnboardingUserDto" : {
-        "title" : "CompanyOnboardingUserDto",
-        "required" : [ "certified", "institutionType", "productId", "taxCode", "users" ],
-        "type" : "object",
-        "properties" : {
-          "certified" : {
-            "type" : "boolean",
-            "description" : "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
-            "example" : false
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
-          },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
-          },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
-          },
-          "users" : {
-            "type" : "array",
-            "description" : "List of onboarding users",
-            "items" : {
-              "$ref" : "#/components/schemas/CompanyUserDto"
-            }
-          }
-        }
-      },
-      "CompanyUserDto" : {
-        "title" : "CompanyUserDto",
-        "required" : [ "name", "role", "surname", "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's email"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
-          },
-          "role" : {
-            "type" : "string",
-            "description" : "User's role",
-            "enum" : [ "ADMIN_EA", "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
-          },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
-          },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
-          }
-        }
-      },
-      "DpoData" : {
-        "title" : "DpoData",
-        "required" : [ "address", "email", "pec" ],
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string",
-            "description" : "DPO's address"
-          },
-          "email" : {
-            "type" : "string",
-            "description" : "DPO's email",
-            "format" : "email",
-            "example" : "email@example.com"
-          },
-          "pec" : {
-            "type" : "string",
-            "description" : "DPO's PEC",
-            "format" : "email",
-            "example" : "email@example.com"
-          }
-        }
-      },
-      "DpoDataDto" : {
-        "title" : "DpoDataDto",
-        "required" : [ "address", "email", "pec" ],
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string",
-            "description" : "DPO's address"
-          },
-          "email" : {
-            "type" : "string",
-            "description" : "DPO's email",
-            "format" : "email",
-            "example" : "email@example.com"
-          },
-          "pec" : {
-            "type" : "string",
-            "description" : "DPO's PEC",
-            "format" : "email",
-            "example" : "email@example.com"
-          }
-        }
-      },
-      "GPUData" : {
-        "title" : "GPUData",
-        "type" : "object",
-        "properties" : {
-          "businessRegisterNumber" : {
-            "type" : "string"
-          },
-          "institutionCourtMeasures" : {
-            "type" : "boolean"
-          },
-          "legalRegisterName" : {
-            "type" : "string"
-          },
-          "legalRegisterNumber" : {
-            "type" : "string"
-          },
-          "manager" : {
-            "type" : "boolean"
-          },
-          "managerAuthorized" : {
-            "type" : "boolean"
-          },
-          "managerEligible" : {
-            "type" : "boolean"
-          },
-          "managerProsecution" : {
-            "type" : "boolean"
-          }
-        }
-      },
-      "GeographicTaxonomyDto" : {
-        "title" : "GeographicTaxonomyDto",
-        "required" : [ "code", "desc" ],
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "type" : "string",
-            "description" : "Institution's geographic taxonomy ISTAT code"
-          },
-          "desc" : {
-            "type" : "string",
-            "description" : "Institution's geographic taxonomy extended name"
-          }
-        }
-      },
-      "GeographicTaxonomyResource" : {
-        "title" : "GeographicTaxonomyResource",
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "type" : "string",
-            "description" : "Institution's geographic taxonomy ISTAT code"
-          },
-          "desc" : {
-            "type" : "string",
-            "description" : "Institution's geographic taxonomy extended name"
-          }
-        }
-      },
-      "InstitutionData" : {
-        "title" : "InstitutionData",
-        "type" : "object",
-        "properties" : {
-          "assistanceContacts" : {
-            "description" : "Institution's assistance contacts",
-            "$ref" : "#/components/schemas/AssistanceContactsResource"
-          },
-          "billingData" : {
-            "description" : "Institution's billing information",
-            "$ref" : "#/components/schemas/BillingDataResponseDto"
-          },
-          "city" : {
-            "type" : "string",
-            "description" : "Institution's city"
-          },
-          "companyInformations" : {
-            "description" : "GPS, SCP, PT optional data",
-            "$ref" : "#/components/schemas/CompanyInformationsResource"
-          },
-          "country" : {
-            "type" : "string",
-            "description" : "Institution's country"
-          },
-          "county" : {
-            "type" : "string",
-            "description" : "Institution's county"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "Institution's unique internal Id"
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
-          },
-          "origin" : {
-            "type" : "string"
-          }
-        }
-      },
-      "InstitutionInfo" : {
-        "title" : "InstitutionInfo",
-        "required" : [ "address", "fiscalCode", "institutionType", "mailAddress", "name", "vatNumber", "zipCode" ],
-        "type" : "object",
-        "properties" : {
-          "additionalInformations" : {
-            "description" : "GSP institution's additional informations",
-            "$ref" : "#/components/schemas/AdditionalInformations"
-          },
-          "address" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
-          },
-          "city" : {
-            "type" : "string",
-            "description" : "Institution's city"
-          },
-          "country" : {
-            "type" : "string",
-            "description" : "Institution's country"
-          },
-          "county" : {
-            "type" : "string",
-            "description" : "Institution's county"
-          },
-          "dpoData" : {
-            "description" : "Data Protection Officer (DPO) specific data",
-            "$ref" : "#/components/schemas/DpoData"
-          },
-          "fiscalCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "Institution's unique internal Id"
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type"
-          },
-          "mailAddress" : {
-            "type" : "string",
-            "description" : "Institution's digitalAddress"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
-          },
-          "pspData" : {
-            "description" : "Payment Service Provider (PSP) specific data",
-            "$ref" : "#/components/schemas/PspData"
-          },
-          "recipientCode" : {
-            "type" : "string",
-            "description" : "Billing recipient code, not required only for institutionType SA"
-          },
-          "taxCodeInvoicing" : {
-            "type" : "string",
-            "description" : "Institution's taxCodeInvoicing for electronic invoicing"
-          },
-          "vatNumber" : {
-            "type" : "string",
-            "description" : "Institution's VAT number"
-          },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
-          }
-        }
-      },
-      "InstitutionLegalAddressResource" : {
-        "title" : "InstitutionLegalAddressResource",
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
-          },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
-          }
-        }
-      },
-      "InstitutionLocationDataDto" : {
-        "title" : "InstitutionLocationDataDto",
-        "type" : "object",
-        "properties" : {
-          "city" : {
-            "type" : "string",
-            "description" : "Institution's city"
-          },
-          "country" : {
-            "type" : "string",
-            "description" : "Institution's country"
-          },
-          "county" : {
-            "type" : "string",
-            "description" : "Institution's county"
-          }
-        }
-      },
-      "InstitutionOnboarding" : {
-        "title" : "InstitutionOnboarding",
-        "type" : "object",
-        "properties" : {
-          "billing" : {
-            "$ref" : "#/components/schemas/Billing"
-          },
-          "closedAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "contract" : {
-            "type" : "string"
-          },
-          "createdAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "pricingPlan" : {
-            "type" : "string"
-          },
-          "productId" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string"
-          },
-          "tokenId" : {
-            "type" : "string"
-          },
-          "updatedAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          }
-        }
-      },
-      "InstitutionOnboardingInfoResource" : {
-        "title" : "InstitutionOnboardingInfoResource",
-        "type" : "object",
-        "properties" : {
-          "geographicTaxonomies" : {
-            "type" : "array",
-            "description" : "Institution's geographic taxonomy",
-            "items" : {
-              "$ref" : "#/components/schemas/GeographicTaxonomyResource"
-            }
-          },
-          "institution" : {
-            "description" : "Institution's billing and type information",
-            "$ref" : "#/components/schemas/InstitutionData"
-          }
-        }
-      },
-      "InstitutionOnboardingResource" : {
-        "title" : "InstitutionOnboardingResource",
-        "type" : "object",
-        "properties" : {
-          "institutionId" : {
-            "type" : "string"
-          },
-          "onboardings" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/InstitutionOnboarding"
+          "users": {
+            "type": "array",
+            "description": "List of onboarding users",
+            "items": {
+              "$ref": "#/components/schemas/CompanyUserDto"
             }
           }
         }
       },
-      "InstitutionResource" : {
-        "title" : "InstitutionResource",
-        "type" : "object",
-        "properties" : {
-          "address" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
+      "CompanyOnboardingUserDto": {
+        "title": "CompanyOnboardingUserDto",
+        "required": [
+          "certified",
+          "institutionType",
+          "productId",
+          "taxCode",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "certified": {
+            "type": "boolean",
+            "description": "Indicates whether the institution values come from INFOCAMERE (true) or MANUAL (false)",
+            "example": false
           },
-          "city" : {
-            "type" : "string",
-            "description" : "Institution's city"
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
           },
-          "country" : {
-            "type" : "string",
-            "description" : "Institution's country"
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
           },
-          "county" : {
-            "type" : "string",
-            "description" : "Institution's county"
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           },
-          "description" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
-          },
-          "digitalAddress" : {
-            "type" : "string",
-            "description" : "Institution's digitalAddress"
-          },
-          "externalId" : {
-            "type" : "string",
-            "description" : "Institution's unique external identifier"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "Institution's unique internal Id",
-            "format" : "uuid"
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type"
-          },
-          "origin" : {
-            "type" : "string",
-            "description" : "Institution data origin"
-          },
-          "originId" : {
-            "type" : "string",
-            "description" : "Institution's details origin Id"
-          },
-          "parentDescription" : {
-            "type" : "string",
-            "description" : "Institution's parent description"
-          },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
-          },
-          "userRole" : {
-            "type" : "string",
-            "description" : "Logged user's role",
-            "enum" : [ "ADMIN", "ADMIN_EA", "LIMITED" ]
-          },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
-          }
-        }
-      },
-      "InstitutionResourceIC" : {
-        "title" : "InstitutionResourceIC",
-        "type" : "object",
-        "properties" : {
-          "businesses" : {
-            "type" : "array",
-            "description" : "Legal Representative's institutions list",
-            "items" : {
-              "$ref" : "#/components/schemas/BusinessResourceIC"
-            }
-          },
-          "legalTaxId" : {
-            "type" : "string",
-            "description" : "Legal Representative's tax ID"
-          },
-          "requestDateTime" : {
-            "type" : "string",
-            "description" : "Timestamp request institutions PNPG list"
-          }
-        }
-      },
-      "InvalidParam" : {
-        "title" : "InvalidParam",
-        "required" : [ "name", "reason" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "Invalid parameter name."
-          },
-          "reason" : {
-            "type" : "string",
-            "description" : "Invalid parameter reason."
-          }
-        }
-      },
-      "MatchInfoResultResource" : {
-        "title" : "MatchInfoResultResource",
-        "type" : "object",
-        "properties" : {
-          "verificationResult" : {
-            "type" : "boolean",
-            "description" : "Legal Representative and Institution match result on Agenzia delle Entrate",
-            "example" : false
-          }
-        }
-      },
-      "OnboardingProductDto" : {
-        "title" : "OnboardingProductDto",
-        "required" : [ "institutionType", "productId", "users" ],
-        "type" : "object",
-        "properties" : {
-          "additionalInformations" : {
-            "description" : "GSP institution's additional informations",
-            "$ref" : "#/components/schemas/AdditionalInformationsDto"
-          },
-          "aggregates" : {
-            "type" : "array",
-            "description" : "List of Aggregate Institutions, not empty only if isAggregator field's value is True",
-            "items" : {
-              "$ref" : "#/components/schemas/AggregateInstitution"
-            }
-          },
-          "assistanceContacts" : {
-            "description" : "Institution's assistance contacts",
-            "$ref" : "#/components/schemas/AssistanceContactsDto"
-          },
-          "billingData" : {
-            "description" : "Institution's billing information",
-            "$ref" : "#/components/schemas/BillingDataDto"
-          },
-          "companyInformations" : {
-            "description" : "GPS, SCP, PT optional data",
-            "$ref" : "#/components/schemas/CompanyInformationsDto"
-          },
-          "geographicTaxonomies" : {
-            "type" : "array",
-            "description" : "List of geographic Taxonomies",
-            "items" : {
-              "$ref" : "#/components/schemas/GeographicTaxonomyDto"
-            }
-          },
-          "gpuData" : {
-            "description" : "Institution's GPU data",
-            "$ref" : "#/components/schemas/GPUData"
-          },
-          "institutionLocationData" : {
-            "description" : "Institution's location data, city, county, country information",
-            "$ref" : "#/components/schemas/InstitutionLocationDataDto"
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
-          },
-          "isAggregator" : {
-            "type" : "boolean",
-            "description" : "specified if given institution is an Aggregator",
-            "example" : false
-          },
-          "origin" : {
-            "type" : "string",
-            "description" : "Institution data origin"
-          },
-          "originId" : {
-            "type" : "string",
-            "description" : "Institution's details origin Id"
-          },
-          "pricingPlan" : {
-            "type" : "string",
-            "description" : "Product's pricing plan"
-          },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
-          },
-          "pspData" : {
-            "description" : "Payment Service Provider (PSP) specific data",
-            "$ref" : "#/components/schemas/PspDataDto"
-          },
-          "subunitCode" : {
-            "type" : "string",
-            "description" : "Institution's subunitCode"
-          },
-          "subunitType" : {
-            "type" : "string",
-            "description" : "Institution's subunitType"
-          },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
-          },
-          "users" : {
-            "type" : "array",
-            "description" : "List of onboarding users",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDto"
+          "users": {
+            "type": "array",
+            "description": "List of onboarding users",
+            "items": {
+              "$ref": "#/components/schemas/CompanyUserDto"
             }
           }
         }
       },
-      "OnboardingRequestResource" : {
-        "title" : "OnboardingRequestResource",
-        "required" : [ "institutionInfo", "status" ],
-        "type" : "object",
-        "properties" : {
-          "admins" : {
-            "type" : "array",
-            "description" : "Administrators specific data",
-            "items" : {
-              "$ref" : "#/components/schemas/UserInfo"
-            }
+      "CompanyUserDto": {
+        "title": "CompanyUserDto",
+        "required": [
+          "name",
+          "role",
+          "surname",
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "User's email"
           },
-          "expiringDate" : {
-            "type" : "string",
-            "description" : "Onboarding request expiring date",
-            "format" : "date-time"
+          "name": {
+            "type": "string",
+            "description": "User's name"
           },
-          "institutionInfo" : {
-            "description" : "Institution specific data",
-            "$ref" : "#/components/schemas/InstitutionInfo"
+          "role": {
+            "type": "string",
+            "description": "User's role",
+            "enum": [
+              "ADMIN_EA",
+              "DELEGATE",
+              "MANAGER",
+              "OPERATOR",
+              "SUB_DELEGATE"
+            ]
           },
-          "manager" : {
-            "description" : "Manager specific data. It's required when institutionType is not PT",
-            "$ref" : "#/components/schemas/UserInfo"
+          "surname": {
+            "type": "string",
+            "description": "User's surname"
           },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
-          },
-          "reasonForReject" : {
-            "type" : "string",
-            "description" : "Onboarding request rejection reason"
-          },
-          "status" : {
-            "type" : "string",
-            "description" : "Onboarding request's status"
-          },
-          "updatedAt" : {
-            "type" : "string",
-            "description" : "Onboarding request update date",
-            "format" : "date-time"
+          "taxCode": {
+            "type": "string",
+            "description": "User's fiscal code"
           }
         }
       },
-      "OnboardingUserDto" : {
-        "title" : "OnboardingUserDto",
-        "required" : [ "productId", "users" ],
-        "type" : "object",
-        "properties" : {
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GPU", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
+      "DpoData": {
+        "title": "DpoData",
+        "required": [
+          "address",
+          "email",
+          "pec"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "DPO's address"
           },
-          "origin" : {
-            "type" : "string",
-            "description" : "Institution data origin"
+          "email": {
+            "type": "string",
+            "description": "DPO's email",
+            "format": "email",
+            "example": "email@example.com"
           },
-          "originId" : {
-            "type" : "string",
-            "description" : "Institution's details origin Id"
+          "pec": {
+            "type": "string",
+            "description": "DPO's PEC",
+            "format": "email",
+            "example": "email@example.com"
+          }
+        }
+      },
+      "DpoDataDto": {
+        "title": "DpoDataDto",
+        "required": [
+          "address",
+          "email",
+          "pec"
+        ],
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "DPO's address"
           },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
+          "email": {
+            "type": "string",
+            "description": "DPO's email",
+            "format": "email",
+            "example": "email@example.com"
           },
-          "subunitCode" : {
-            "type" : "string",
-            "description" : "Institution's subunitCode"
+          "pec": {
+            "type": "string",
+            "description": "DPO's PEC",
+            "format": "email",
+            "example": "email@example.com"
+          }
+        }
+      },
+      "GPUData": {
+        "title": "GPUData",
+        "type": "object",
+        "properties": {
+          "businessRegisterNumber": {
+            "type": "string"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+          "institutionCourtMeasures": {
+            "type": "boolean"
           },
-          "users" : {
-            "type" : "array",
-            "description" : "List of onboarding users",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDto"
+          "legalRegisterName": {
+            "type": "string"
+          },
+          "legalRegisterNumber": {
+            "type": "string"
+          },
+          "manager": {
+            "type": "boolean"
+          },
+          "managerAuthorized": {
+            "type": "boolean"
+          },
+          "managerEligible": {
+            "type": "boolean"
+          },
+          "managerProsecution": {
+            "type": "boolean"
+          }
+        }
+      },
+      "GeographicTaxonomyDto": {
+        "title": "GeographicTaxonomyDto",
+        "required": [
+          "code",
+          "desc"
+        ],
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Institution's geographic taxonomy ISTAT code"
+          },
+          "desc": {
+            "type": "string",
+            "description": "Institution's geographic taxonomy extended name"
+          }
+        }
+      },
+      "GeographicTaxonomyResource": {
+        "title": "GeographicTaxonomyResource",
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Institution's geographic taxonomy ISTAT code"
+          },
+          "desc": {
+            "type": "string",
+            "description": "Institution's geographic taxonomy extended name"
+          }
+        }
+      },
+      "InstitutionData": {
+        "title": "InstitutionData",
+        "type": "object",
+        "properties": {
+          "assistanceContacts": {
+            "description": "Institution's assistance contacts",
+            "$ref": "#/components/schemas/AssistanceContactsResource"
+          },
+          "billingData": {
+            "description": "Institution's billing information",
+            "$ref": "#/components/schemas/BillingDataResponseDto"
+          },
+          "city": {
+            "type": "string",
+            "description": "Institution's city"
+          },
+          "companyInformations": {
+            "description": "GPS, SCP, PT optional data",
+            "$ref": "#/components/schemas/CompanyInformationsResource"
+          },
+          "country": {
+            "type": "string",
+            "description": "Institution's country"
+          },
+          "county": {
+            "type": "string",
+            "description": "Institution's county"
+          },
+          "id": {
+            "type": "string",
+            "description": "Institution's unique internal Id"
+          },
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
+          },
+          "origin": {
+            "type": "string"
+          }
+        }
+      },
+      "InstitutionInfo": {
+        "title": "InstitutionInfo",
+        "required": [
+          "address",
+          "fiscalCode",
+          "institutionType",
+          "mailAddress",
+          "name",
+          "vatNumber",
+          "zipCode"
+        ],
+        "type": "object",
+        "properties": {
+          "additionalInformations": {
+            "description": "GSP institution's additional informations",
+            "$ref": "#/components/schemas/AdditionalInformations"
+          },
+          "address": {
+            "type": "string",
+            "description": "Institution's physical address"
+          },
+          "city": {
+            "type": "string",
+            "description": "Institution's city"
+          },
+          "country": {
+            "type": "string",
+            "description": "Institution's country"
+          },
+          "county": {
+            "type": "string",
+            "description": "Institution's county"
+          },
+          "dpoData": {
+            "description": "Data Protection Officer (DPO) specific data",
+            "$ref": "#/components/schemas/DpoData"
+          },
+          "fiscalCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "id": {
+            "type": "string",
+            "description": "Institution's unique internal Id"
+          },
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type"
+          },
+          "mailAddress": {
+            "type": "string",
+            "description": "Institution's digitalAddress"
+          },
+          "name": {
+            "type": "string",
+            "description": "Institution's legal name"
+          },
+          "pspData": {
+            "description": "Payment Service Provider (PSP) specific data",
+            "$ref": "#/components/schemas/PspData"
+          },
+          "recipientCode": {
+            "type": "string",
+            "description": "Billing recipient code, not required only for institutionType SA"
+          },
+          "taxCodeInvoicing": {
+            "type": "string",
+            "description": "Institution's taxCodeInvoicing for electronic invoicing"
+          },
+          "vatNumber": {
+            "type": "string",
+            "description": "Institution's VAT number"
+          },
+          "zipCode": {
+            "type": "string",
+            "description": "Institution's zipCode"
+          }
+        }
+      },
+      "InstitutionLegalAddressResource": {
+        "title": "InstitutionLegalAddressResource",
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Institution's physical address"
+          },
+          "zipCode": {
+            "type": "string",
+            "description": "Institution's zipCode"
+          }
+        }
+      },
+      "InstitutionLocationDataDto": {
+        "title": "InstitutionLocationDataDto",
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "description": "Institution's city"
+          },
+          "country": {
+            "type": "string",
+            "description": "Institution's country"
+          },
+          "county": {
+            "type": "string",
+            "description": "Institution's county"
+          }
+        }
+      },
+      "InstitutionOnboarding": {
+        "title": "InstitutionOnboarding",
+        "type": "object",
+        "properties": {
+          "billing": {
+            "$ref": "#/components/schemas/Billing"
+          },
+          "closedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contract": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pricingPlan": {
+            "type": "string"
+          },
+          "productId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "InstitutionOnboardingInfoResource": {
+        "title": "InstitutionOnboardingInfoResource",
+        "type": "object",
+        "properties": {
+          "geographicTaxonomies": {
+            "type": "array",
+            "description": "Institution's geographic taxonomy",
+            "items": {
+              "$ref": "#/components/schemas/GeographicTaxonomyResource"
+            }
+          },
+          "institution": {
+            "description": "Institution's billing and type information",
+            "$ref": "#/components/schemas/InstitutionData"
+          }
+        }
+      },
+      "InstitutionOnboardingResource": {
+        "title": "InstitutionOnboardingResource",
+        "type": "object",
+        "properties": {
+          "institutionId": {
+            "type": "string"
+          },
+          "onboardings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstitutionOnboarding"
             }
           }
         }
       },
-      "OnboardingVerify" : {
-        "title" : "OnboardingVerify",
-        "required" : [ "status" ],
-        "type" : "object",
-        "properties" : {
-          "expiringDate" : {
-            "type" : "string",
-            "description" : "Onboarding request expiring date",
-            "format" : "date-time"
+      "InstitutionResource": {
+        "title": "InstitutionResource",
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Institution's physical address"
           },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
+          "city": {
+            "type": "string",
+            "description": "Institution's city"
           },
-          "status" : {
-            "type" : "string",
-            "description" : "Onboarding request's status"
+          "country": {
+            "type": "string",
+            "description": "Institution's country"
+          },
+          "county": {
+            "type": "string",
+            "description": "Institution's county"
+          },
+          "description": {
+            "type": "string",
+            "description": "Institution's legal name"
+          },
+          "digitalAddress": {
+            "type": "string",
+            "description": "Institution's digitalAddress"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "Institution's unique external identifier"
+          },
+          "id": {
+            "type": "string",
+            "description": "Institution's unique internal Id",
+            "format": "uuid"
+          },
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type"
+          },
+          "origin": {
+            "type": "string",
+            "description": "Institution data origin"
+          },
+          "originId": {
+            "type": "string",
+            "description": "Institution's details origin Id"
+          },
+          "parentDescription": {
+            "type": "string",
+            "description": "Institution's parent description"
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "userRole": {
+            "type": "string",
+            "description": "Logged user's role",
+            "enum": [
+              "ADMIN",
+              "ADMIN_EA",
+              "LIMITED"
+            ]
+          },
+          "zipCode": {
+            "type": "string",
+            "description": "Institution's zipCode"
           }
         }
       },
-      "Problem" : {
-        "title" : "Problem",
-        "required" : [ "status", "title" ],
-        "type" : "object",
-        "properties" : {
-          "detail" : {
-            "type" : "string",
-            "description" : "Human-readable description of this specific problem."
-          },
-          "instance" : {
-            "type" : "string",
-            "description" : "A URI that describes where the problem occurred."
-          },
-          "invalidParams" : {
-            "type" : "array",
-            "description" : "A list of invalid parameters details.",
-            "items" : {
-              "$ref" : "#/components/schemas/InvalidParam"
+      "InstitutionResourceIC": {
+        "title": "InstitutionResourceIC",
+        "type": "object",
+        "properties": {
+          "businesses": {
+            "type": "array",
+            "description": "Legal Representative's institutions list",
+            "items": {
+              "$ref": "#/components/schemas/BusinessResourceIC"
             }
           },
-          "status" : {
-            "type" : "integer",
-            "description" : "The HTTP status code.",
-            "format" : "int32",
-            "example" : 500
+          "legalTaxId": {
+            "type": "string",
+            "description": "Legal Representative's tax ID"
           },
-          "title" : {
-            "type" : "string",
-            "description" : "Short human-readable summary of the problem."
+          "requestDateTime": {
+            "type": "string",
+            "description": "Timestamp request institutions PNPG list"
+          }
+        }
+      },
+      "InvalidParam": {
+        "title": "InvalidParam",
+        "required": [
+          "name",
+          "reason"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Invalid parameter name."
           },
-          "type" : {
-            "type" : "string",
-            "description" : "A URL to a page with more details regarding the problem."
+          "reason": {
+            "type": "string",
+            "description": "Invalid parameter reason."
+          }
+        }
+      },
+      "ManagerInfoResponse": {
+        "title": "ManagerInfoResponse",
+        "required": [
+          "name",
+          "surname"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "User's name"
+          },
+          "surname": {
+            "type": "string",
+            "description": "User's surname"
+          }
+        }
+      },
+      "MatchInfoResultResource": {
+        "title": "MatchInfoResultResource",
+        "type": "object",
+        "properties": {
+          "verificationResult": {
+            "type": "boolean",
+            "description": "Legal Representative and Institution match result on Agenzia delle Entrate",
+            "example": false
+          }
+        }
+      },
+      "OnboardingProductDto": {
+        "title": "OnboardingProductDto",
+        "required": [
+          "institutionType",
+          "productId",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "additionalInformations": {
+            "description": "GSP institution's additional informations",
+            "$ref": "#/components/schemas/AdditionalInformationsDto"
+          },
+          "aggregates": {
+            "type": "array",
+            "description": "List of Aggregate Institutions, not empty only if isAggregator field's value is True",
+            "items": {
+              "$ref": "#/components/schemas/AggregateInstitution"
+            }
+          },
+          "assistanceContacts": {
+            "description": "Institution's assistance contacts",
+            "$ref": "#/components/schemas/AssistanceContactsDto"
+          },
+          "billingData": {
+            "description": "Institution's billing information",
+            "$ref": "#/components/schemas/BillingDataDto"
+          },
+          "companyInformations": {
+            "description": "GPS, SCP, PT optional data",
+            "$ref": "#/components/schemas/CompanyInformationsDto"
+          },
+          "geographicTaxonomies": {
+            "type": "array",
+            "description": "List of geographic Taxonomies",
+            "items": {
+              "$ref": "#/components/schemas/GeographicTaxonomyDto"
+            }
+          },
+          "gpuData": {
+            "description": "Institution's GPU data",
+            "$ref": "#/components/schemas/GPUData"
+          },
+          "institutionLocationData": {
+            "description": "Institution's location data, city, county, country information",
+            "$ref": "#/components/schemas/InstitutionLocationDataDto"
+          },
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
+          },
+          "isAggregator": {
+            "type": "boolean",
+            "description": "specified if given institution is an Aggregator",
+            "example": false
+          },
+          "origin": {
+            "type": "string",
+            "description": "Institution data origin"
+          },
+          "originId": {
+            "type": "string",
+            "description": "Institution's details origin Id"
+          },
+          "pricingPlan": {
+            "type": "string",
+            "description": "Product's pricing plan"
+          },
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
+          },
+          "pspData": {
+            "description": "Payment Service Provider (PSP) specific data",
+            "$ref": "#/components/schemas/PspDataDto"
+          },
+          "subunitCode": {
+            "type": "string",
+            "description": "Institution's subunitCode"
+          },
+          "subunitType": {
+            "type": "string",
+            "description": "Institution's subunitType"
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "users": {
+            "type": "array",
+            "description": "List of onboarding users",
+            "items": {
+              "$ref": "#/components/schemas/UserDto"
+            }
+          }
+        }
+      },
+      "OnboardingRequestResource": {
+        "title": "OnboardingRequestResource",
+        "required": [
+          "institutionInfo",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "admins": {
+            "type": "array",
+            "description": "Administrators specific data",
+            "items": {
+              "$ref": "#/components/schemas/UserInfo"
+            }
+          },
+          "expiringDate": {
+            "type": "string",
+            "description": "Onboarding request expiring date",
+            "format": "date-time"
+          },
+          "institutionInfo": {
+            "description": "Institution specific data",
+            "$ref": "#/components/schemas/InstitutionInfo"
+          },
+          "manager": {
+            "description": "Manager specific data. It's required when institutionType is not PT",
+            "$ref": "#/components/schemas/UserInfo"
+          },
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
+          },
+          "reasonForReject": {
+            "type": "string",
+            "description": "Onboarding request rejection reason"
+          },
+          "status": {
+            "type": "string",
+            "description": "Onboarding request's status"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Onboarding request update date",
+            "format": "date-time"
+          }
+        }
+      },
+      "OnboardingUserDto": {
+        "title": "OnboardingUserDto",
+        "required": [
+          "productId",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "institutionType": {
+            "type": "string",
+            "description": "Institution's type",
+            "enum": [
+              "AS",
+              "CON",
+              "GPU",
+              "GSP",
+              "PA",
+              "PG",
+              "PRV",
+              "PSP",
+              "PT",
+              "REC",
+              "SA",
+              "SCP"
+            ]
+          },
+          "origin": {
+            "type": "string",
+            "description": "Institution data origin"
+          },
+          "originId": {
+            "type": "string",
+            "description": "Institution's details origin Id"
+          },
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
+          },
+          "subunitCode": {
+            "type": "string",
+            "description": "Institution's subunitCode"
+          },
+          "taxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
+          },
+          "users": {
+            "type": "array",
+            "description": "List of onboarding users",
+            "items": {
+              "$ref": "#/components/schemas/UserDto"
+            }
+          }
+        }
+      },
+      "OnboardingVerify": {
+        "title": "OnboardingVerify",
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "expiringDate": {
+            "type": "string",
+            "description": "Onboarding request expiring date",
+            "format": "date-time"
+          },
+          "productId": {
+            "type": "string",
+            "description": "Product's unique identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Onboarding request's status"
+          }
+        }
+      },
+      "Problem": {
+        "title": "Problem",
+        "required": [
+          "status",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable description of this specific problem."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI that describes where the problem occurred."
+          },
+          "invalidParams": {
+            "type": "array",
+            "description": "A list of invalid parameters details.",
+            "items": {
+              "$ref": "#/components/schemas/InvalidParam"
+            }
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code.",
+            "format": "int32",
+            "example": 500
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable summary of the problem."
+          },
+          "type": {
+            "type": "string",
+            "description": "A URL to a page with more details regarding the problem."
           }
         },
-        "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
+        "description": "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
       },
-      "ProductResource" : {
-        "title" : "ProductResource",
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "description" : "Product's unique identifier"
+      "ProductResource": {
+        "title": "ProductResource",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Product's unique identifier"
           },
-          "logo" : {
-            "type" : "string",
-            "description" : "Product's logo"
+          "logo": {
+            "type": "string",
+            "description": "Product's logo"
           },
-          "logoBgColor" : {
-            "type" : "string",
-            "description" : "Product logo's background color"
+          "logoBgColor": {
+            "type": "string",
+            "description": "Product logo's background color"
           },
-          "parentId" : {
-            "type" : "string",
-            "description" : "Product's parent's Id"
+          "parentId": {
+            "type": "string",
+            "description": "Product's parent's Id"
           },
-          "status" : {
-            "type" : "string",
-            "description" : "Product's status",
-            "enum" : [ "ACTIVE", "INACTIVE", "PHASE_OUT", "TESTING" ]
+          "status": {
+            "type": "string",
+            "description": "Product's status",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE",
+              "PHASE_OUT",
+              "TESTING"
+            ]
           },
-          "title" : {
-            "type" : "string",
-            "description" : "Product's title"
+          "title": {
+            "type": "string",
+            "description": "Product's title"
           }
         }
       },
-      "PspData" : {
-        "title" : "PspData",
-        "required" : [ "abiCode", "businessRegisterNumber", "legalRegisterName", "legalRegisterNumber", "vatNumberGroup" ],
-        "type" : "object",
-        "properties" : {
-          "abiCode" : {
-            "type" : "string",
-            "description" : "PSP's ABI code"
+      "PspData": {
+        "title": "PspData",
+        "required": [
+          "abiCode",
+          "businessRegisterNumber",
+          "legalRegisterName",
+          "legalRegisterNumber",
+          "vatNumberGroup"
+        ],
+        "type": "object",
+        "properties": {
+          "abiCode": {
+            "type": "string",
+            "description": "PSP's ABI code"
           },
-          "businessRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's Business Register number"
+          "businessRegisterNumber": {
+            "type": "string",
+            "description": "PSP's Business Register number"
           },
-          "legalRegisterName" : {
-            "type" : "string",
-            "description" : "PSP's legal register name"
+          "legalRegisterName": {
+            "type": "string",
+            "description": "PSP's legal register name"
           },
-          "legalRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's legal register number"
+          "legalRegisterNumber": {
+            "type": "string",
+            "description": "PSP's legal register number"
           },
-          "vatNumberGroup" : {
-            "type" : "boolean",
-            "description" : "PSP's Vat Number group",
-            "example" : false
+          "vatNumberGroup": {
+            "type": "boolean",
+            "description": "PSP's Vat Number group",
+            "example": false
           }
         }
       },
-      "PspDataDto" : {
-        "title" : "PspDataDto",
-        "required" : [ "abiCode", "businessRegisterNumber", "dpoData", "legalRegisterName", "legalRegisterNumber", "vatNumberGroup" ],
-        "type" : "object",
-        "properties" : {
-          "abiCode" : {
-            "type" : "string",
-            "description" : "PSP's ABI code"
+      "PspDataDto": {
+        "title": "PspDataDto",
+        "required": [
+          "abiCode",
+          "businessRegisterNumber",
+          "dpoData",
+          "legalRegisterName",
+          "legalRegisterNumber",
+          "vatNumberGroup"
+        ],
+        "type": "object",
+        "properties": {
+          "abiCode": {
+            "type": "string",
+            "description": "PSP's ABI code"
           },
-          "businessRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's Business Register number"
+          "businessRegisterNumber": {
+            "type": "string",
+            "description": "PSP's Business Register number"
           },
-          "dpoData" : {
-            "description" : "Data Protection Officer (DPO) specific data",
-            "$ref" : "#/components/schemas/DpoDataDto"
+          "dpoData": {
+            "description": "Data Protection Officer (DPO) specific data",
+            "$ref": "#/components/schemas/DpoDataDto"
           },
-          "legalRegisterName" : {
-            "type" : "string",
-            "description" : "PSP's legal register name"
+          "legalRegisterName": {
+            "type": "string",
+            "description": "PSP's legal register name"
           },
-          "legalRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's legal register number"
+          "legalRegisterNumber": {
+            "type": "string",
+            "description": "PSP's legal register number"
           },
-          "vatNumberGroup" : {
-            "type" : "boolean",
-            "description" : "PSP's Vat Number group",
-            "example" : false
+          "vatNumberGroup": {
+            "type": "boolean",
+            "description": "PSP's Vat Number group",
+            "example": false
           }
         }
       },
-      "ReasonForRejectDto" : {
-        "title" : "ReasonForRejectDto",
-        "type" : "object",
-        "properties" : {
-          "reason" : {
-            "type" : "string",
-            "description" : "Rejection reason of an onboarding request"
+      "ReasonForRejectDto": {
+        "title": "ReasonForRejectDto",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Rejection reason of an onboarding request"
           }
         }
       },
-      "RowErrorResponse" : {
-        "title" : "RowErrorResponse",
-        "type" : "object",
-        "properties" : {
-          "codice fiscale" : {
-            "type" : "string"
+      "RowErrorResponse": {
+        "title": "RowErrorResponse",
+        "type": "object",
+        "properties": {
+          "codice fiscale": {
+            "type": "string"
           },
-          "errore" : {
-            "type" : "string"
+          "errore": {
+            "type": "string"
           },
-          "riga" : {
-            "type" : "integer",
-            "format" : "int32"
+          "riga": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
-      "UserDataValidationDto" : {
-        "title" : "UserDataValidationDto",
-        "required" : [ "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
+      "UserDataValidationDto": {
+        "title": "UserDataValidationDto",
+        "required": [
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "User's name"
           },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
+          "surname": {
+            "type": "string",
+            "description": "User's surname"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
+          "taxCode": {
+            "type": "string",
+            "description": "User's fiscal code"
           }
         }
       },
-      "UserDto" : {
-        "title" : "UserDto",
-        "required" : [ "name", "role", "surname", "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's email"
+      "UserDto": {
+        "title": "UserDto",
+        "required": [
+          "name",
+          "role",
+          "surname",
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "User's email"
           },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
+          "name": {
+            "type": "string",
+            "description": "User's name"
           },
-          "role" : {
-            "type" : "string",
-            "description" : "User's role",
-            "enum" : [ "ADMIN_EA", "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
+          "role": {
+            "type": "string",
+            "description": "User's role",
+            "enum": [
+              "ADMIN_EA",
+              "DELEGATE",
+              "MANAGER",
+              "OPERATOR",
+              "SUB_DELEGATE"
+            ]
           },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
+          "surname": {
+            "type": "string",
+            "description": "User's surname"
           },
-          "taxCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
+          "taxCode": {
+            "type": "string",
+            "description": "User's fiscal code"
           }
         }
       },
-      "UserInfo" : {
-        "title" : "UserInfo",
-        "required" : [ "email", "fiscalCode", "id", "name", "surname" ],
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's institutional email"
+      "UserInfo": {
+        "title": "UserInfo",
+        "required": [
+          "email",
+          "fiscalCode",
+          "id",
+          "name",
+          "surname"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "User's institutional email"
           },
-          "fiscalCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
+          "fiscalCode": {
+            "type": "string",
+            "description": "User's fiscal code"
           },
-          "id" : {
-            "type" : "string",
-            "description" : "User's unique identifier",
-            "format" : "uuid"
+          "id": {
+            "type": "string",
+            "description": "User's unique identifier",
+            "format": "uuid"
           },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
+          "name": {
+            "type": "string",
+            "description": "User's name"
           },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
+          "surname": {
+            "type": "string",
+            "description": "User's surname"
           }
         }
       },
-      "VerificationLegalAddressRequest" : {
-        "title" : "VerificationLegalAddressRequest",
-        "required" : [ "taxCode" ],
-        "type" : "object",
-        "properties" : {
-          "taxCode" : {
-            "type" : "string"
+      "VerificationLegalAddressRequest": {
+        "title": "VerificationLegalAddressRequest",
+        "required": [
+          "taxCode"
+        ],
+        "type": "object",
+        "properties": {
+          "taxCode": {
+            "type": "string"
           }
         }
       },
-      "VerificationMatchRequest" : {
-        "title" : "VerificationMatchRequest",
-        "required" : [ "taxCode", "userDto" ],
-        "type" : "object",
-        "properties" : {
-          "taxCode" : {
-            "type" : "string"
+      "VerificationMatchRequest": {
+        "title": "VerificationMatchRequest",
+        "required": [
+          "taxCode",
+          "userDto"
+        ],
+        "type": "object",
+        "properties": {
+          "taxCode": {
+            "type": "string"
           },
-          "userDto" : {
-            "$ref" : "#/components/schemas/UserDto"
+          "userDto": {
+            "$ref": "#/components/schemas/UserDto"
           }
         }
       },
-      "VerifyAggregatesResponse" : {
-        "title" : "VerifyAggregatesResponse",
-        "type" : "object",
-        "properties" : {
-          "aggregates" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AggregateResult"
+      "VerifyAggregatesResponse": {
+        "title": "VerifyAggregatesResponse",
+        "type": "object",
+        "properties": {
+          "aggregates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AggregateResult"
             }
           },
-          "errors" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/RowErrorResponse"
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowErrorResponse"
             }
           }
         }
       },
-      "VerifyManagerRequest" : {
-        "title" : "VerifyManagerRequest",
-        "type" : "object",
-        "properties" : {
-          "companyTaxCode" : {
-            "type" : "string",
-            "description" : "Institution's taxCode"
+      "VerifyManagerRequest": {
+        "title": "VerifyManagerRequest",
+        "type": "object",
+        "properties": {
+          "companyTaxCode": {
+            "type": "string",
+            "description": "Institution's taxCode"
           },
-          "userTaxCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
+          "userTaxCode": {
+            "type": "string",
+            "description": "User's fiscal code"
           }
         }
       },
-      "VerifyManagerResponse" : {
-        "title" : "VerifyManagerResponse",
-        "type" : "object",
-        "properties" : {
-          "companyName" : {
-            "type" : "string",
-            "description" : "Institution's legal name"
+      "VerifyManagerResponse": {
+        "title": "VerifyManagerResponse",
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": "string",
+            "description": "Institution's legal name"
           },
-          "origin" : {
-            "type" : "string",
-            "description" : "Institution data origin"
+          "origin": {
+            "type": "string",
+            "description": "Institution data origin"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "bearerAuth" : {
-        "type" : "http",
-        "description" : "A bearer token in the format of a JWS and conformed to the specifications included in [RFC8725](https://tools.ietf.org/html/RFC8725)",
-        "scheme" : "bearer",
-        "bearerFormat" : "JWT"
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "description": "A bearer token in the format of a JWS and conformed to the specifications included in [RFC8725](https://tools.ietf.org/html/RFC8725)",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mui/x-data-grid": "^5.0.1",
     "@mui/x-data-grid-generator": "^5.0.1",
     "@pagopa/mui-italia": "^1.5.0",
-    "@pagopa/selfcare-common-frontend": "^1.34.51",
+    "@pagopa/selfcare-common-frontend": "^1.34.55",
     "axios": "^0.28.0",
     "formik": "^2.2.9",
     "i18next": "^23.7.11",

--- a/src/api/OnboardingApiClient.tsx
+++ b/src/api/OnboardingApiClient.tsx
@@ -14,6 +14,7 @@ import { RoleEnum, CompanyUserDto } from './generated/b4f-onboarding/CompanyUser
 import { InstitutionOnboardingResource } from './generated/b4f-onboarding/InstitutionOnboardingResource';
 import { VerifyManagerResponse } from './generated/b4f-onboarding/VerifyManagerResponse';
 import { CheckManagerResponse } from './generated/b4f-onboarding/CheckManagerResponse';
+import { ManagerInfoResponse } from './generated/b4f-onboarding/ManagerInfoResponse';
 
 const withBearerAndInstitutionId: WithDefaultsT<'bearerAuth'> =
   (wrappedOperation) => (params: any) => {
@@ -52,6 +53,11 @@ export const OnboardingApi = {
     const result = await apiClient.verifyManagerUsingPOST({
       body: { companyTaxCode, userTaxCode },
     });
+    return extractResponse(result, 200, onRedirectToLogin);
+  },
+
+  getManagerInfo: async (onboardingId: string): Promise<ManagerInfoResponse> => {
+    const result = await apiClient.checkManager_1({ onboardingId });
     return extractResponse(result, 200, onRedirectToLogin);
   },
 

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -66,10 +66,7 @@ export const checkManager = async (
   }
 };
 
-export const getManagerOfOnboarding = async (
-  onboardingId: string,
-  sessionToken: string
-): Promise<Response | any> => {
+export const getManagerOfOnboarding = async (onboardingId: string): Promise<Response | any> => {
   /* istanbul ignore if */
   if (process.env.REACT_APP_MOCK_API === 'true') {
     return {
@@ -77,16 +74,7 @@ export const getManagerOfOnboarding = async (
       surname: 'Cognome',
     };
   } else {
-    return fetch(`${ENV.URL_API.ONBOARDING}/users/onboarding/${onboardingId}/manager`, {
-      headers: {
-        accept: '*/*',
-        'accept-language': 'it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7',
-        Authorization: `Bearer ${sessionToken}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'GET',
-      mode: 'cors'
-    });
+    return OnboardingApi.getManagerInfo(onboardingId);
   }
 };
 

--- a/src/services/onboardingService.ts
+++ b/src/services/onboardingService.ts
@@ -66,6 +66,30 @@ export const checkManager = async (
   }
 };
 
+export const getManagerOfOnboarding = async (
+  onboardingId: string,
+  sessionToken: string
+): Promise<Response | any> => {
+  /* istanbul ignore if */
+  if (process.env.REACT_APP_MOCK_API === 'true') {
+    return {
+      name: 'Nome',
+      surname: 'Cognome',
+    };
+  } else {
+    return fetch(`${ENV.URL_API.ONBOARDING}/users/onboarding/${onboardingId}/manager`, {
+      headers: {
+        accept: '*/*',
+        'accept-language': 'it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7',
+        Authorization: `Bearer ${sessionToken}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'GET',
+      mode: 'cors'
+    });
+  }
+};
+
 export const onboardingPGSubmit = (
   businessId: string,
   productId: string,

--- a/src/utils/models/VerificationResult.ts
+++ b/src/utils/models/VerificationResult.ts
@@ -1,3 +1,8 @@
 export type VerificationResult = {
   result: boolean;
 };
+
+export type FirstManagerInfo = {
+  name: string;
+  surname: string;
+};

--- a/src/views/Onboarding/components/OutcomeHandler.tsx
+++ b/src/views/Onboarding/components/OutcomeHandler.tsx
@@ -72,6 +72,7 @@ export default function OutcomeHandler({
     <NotManagerButLR
       handleOnboardingUsersSubmit={handleOnboardingUsersSubmit}
       companyData={companyData}
+      setLoading={setLoading}
     />
   ) : outcome === 'genericError' ? (
     <EndingPage

--- a/src/views/Onboarding/pages/NotManagerButLR.tsx
+++ b/src/views/Onboarding/pages/NotManagerButLR.tsx
@@ -1,8 +1,5 @@
 import { Trans } from 'react-i18next';
-import {
-  storageTokenOps,
-  storageUserOps,
-} from '@pagopa/selfcare-common-frontend/lib/utils/storage';
+import { storageUserOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import { Grid, Typography, Box, Button, Card } from '@mui/material';
 import LocationCityIcon from '@mui/icons-material/LocationCity';
 import { theme } from '@pagopa/mui-italia';
@@ -23,7 +20,6 @@ type Props = {
 function NotManagerButLR({ handleOnboardingUsersSubmit, companyData, setLoading }: Props) {
   const { user } = useContext(UserContext);
   const loggedUser = MOCK_USER ? (user as User) : storageUserOps.read();
-  const sessionToken = storageTokenOps.read();
   const createdAt = companyData?.onboardings
     ? (companyData?.onboardings[0].createdAt as unknown as string)
     : undefined;
@@ -35,41 +31,27 @@ function NotManagerButLR({ handleOnboardingUsersSubmit, companyData, setLoading 
   });
   const addError = useErrorDispatcher();
 
-  const getFirstManagerInfo = async (tokenId: string, sessionToken: string) => {
+  const getFirstManagerInfo = async (tokenId: string) => {
     setLoading(true);
-    try {
-      if (tokenId) {
-        const response = await getManagerOfOnboarding(
-          '94c39ab1-e8ff-4608-8343-6c18eff720a1',
-          sessionToken
-        );
-
-        if (!response.ok) {
-          console.error('API call failed:', response.status, response.statusText);
-        }
-
-        const firstManagerResponse = await response.json();
-        console.log('firstManagerResponse', firstManagerResponse);
-        if (firstManagerResponse) {
-          setFirstManagerInfo(firstManagerResponse);
-        }
-      }
-    } catch (reason: any) {
-      addError({
-        id: 'ONBOARDING_PNPG_GETTING_FIRST_MANAGER_INFO_ERROR',
-        blocking: false,
-        error: reason,
-        techDescription: `An error occurred while getting first manager info: ${reason.message}`,
-        toNotify: true,
+    getManagerOfOnboarding(tokenId)
+      .then((res) => setFirstManagerInfo(res))
+      .catch((reason: any) => {
+        addError({
+          id: 'ONBOARDING_PNPG_GETTING_FIRST_MANAGER_INFO_ERROR',
+          blocking: false,
+          error: reason,
+          techDescription: `An error occurred while getting first manager info: ${reason.message}`,
+          toNotify: true,
+        });
+      })
+      .finally(() => {
+        setLoading(false);
       });
-    } finally {
-      setLoading(false);
-    }
   };
 
   useEffect(() => {
     if (Array.isArray(companyData?.onboardings) && companyData?.onboardings[0].tokenId) {
-      void getFirstManagerInfo(companyData?.onboardings[0].tokenId, sessionToken);
+      void getFirstManagerInfo(companyData?.onboardings[0].tokenId);
     }
   }, [companyData?.institutionId]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,10 +2226,10 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/selfcare-common-frontend@^1.34.51":
-  version "1.34.51"
-  resolved "https://registry.npmjs.org/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.51.tgz#d6c89b8f3f977c2e8954e1d4081f34484a6aa3b4"
-  integrity sha512-herIua+pko66rULhO0ztGra66yQdXB3F2iLvU9SGQWRlp9StENtjOGXiQIUDSm7EUS8BTivKRuLmGGU0lItalw==
+"@pagopa/selfcare-common-frontend@^1.34.55":
+  version "1.34.55"
+  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.55.tgz#1caf14eade366e8487ac0e532404885256274020"
+  integrity sha512-SiWOUde5HtwfmOj8QZj6CGgnWwXhs1Ca8DHdxQX5l7MpGpjM0JN6K1GomaFOO0PZLQESE22Z2U4fZ0tr9qR7fA==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@emotion/styled" "^11.11.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-6357] Feat: Recover the LR that first onboards the business

#### Motivation and Context

the features that recover the LR that first onboards the business it's needed to display to video the name and surname of the LR

#### How Has This Been Tested?

Tested that the api getActiveOnoarding respond also with the tokenId of the onboarding, that it's the data needed to fire the api of getManagerOfOnboarding that responde with the name and the surname of the LR that first onboard the business.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6357]: https://pagopa.atlassian.net/browse/SELC-6357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ